### PR TITLE
FacebookRequest:setAccessToken(): phpdoc update: accepts null as an argument

### DIFF
--- a/src/Facebook/FacebookRequest.php
+++ b/src/Facebook/FacebookRequest.php
@@ -108,7 +108,7 @@ class FacebookRequest
     /**
      * Set the access token for this request.
      *
-     * @param AccessToken|string
+     * @param AccessToken|string|null
      *
      * @return FacebookRequest
      */


### PR DESCRIPTION
It's called from the constructor which clearly allows null (in its phpdoc)
