### PR TITLE
Fix: Method does not return anything

### DIFF
--- a/src/Facebook/FacebookBatchRequest.php
+++ b/src/Facebook/FacebookBatchRequest.php
@@ -168,8 +168,6 @@ class FacebookBatchRequest extends FacebookRequest implements IteratorAggregate,
 
     /**
      * Prepares the requests to be sent as a batch request.
-     *
-     * @return string
      */
     public function prepareRequestsForBatch()
     {


### PR DESCRIPTION
This PR

* [x] updates a docblock for a method that doesn't return anything