### PR TITLE
Made AccessToken::isLongLived conform to the documentation.

### DIFF
--- a/src/Facebook/Authentication/AccessToken.php
+++ b/src/Facebook/Authentication/AccessToken.php
@@ -93,7 +93,7 @@ class AccessToken
     /**
      * Determines whether or not this is a long-lived token.
      *
-     * @return bool
+     * @return bool|null
      */
     public function isLongLived()
     {
@@ -105,7 +105,7 @@ class AccessToken
             return true;
         }
 
-        return false;
+        return null;
     }
 
     /**


### PR DESCRIPTION
The `AccessToken::isLongLived` method is not conform to the documentation.
This PR fixes this issue by modifying the returned value in this particular case, to meet the docs.

The doc says:

>If the expiration date was not originally provided, the method will return `null`.

https://github.com/facebook/php-graph-sdk/blob/master/docs/AccessToken.fbmd#L31
