### PR TITLE
fixed invalid format handling of headers[x-fb-ads-insights-throttle]

### DIFF
--- a/src/Facebook/Http/GraphRawResponse.php
+++ b/src/Facebook/Http/GraphRawResponse.php
@@ -129,7 +129,7 @@ class GraphRawResponse
             if (strpos($line, ': ') === false) {
                 $this->setHttpResponseCodeFromHeader($line);
             } else {
-                list($key, $value) = explode(': ', $line);
+                list($key, $value) = explode(': ', $line, 2);
                 $this->headers[$key] = $value;
             }
         }


### PR DESCRIPTION
The raw response header field "X-FB-Ads-Insights-Throttle" contains a json value { "app_id_util_pct": 100, "acc_id_util_pct": 10 }

Calling $response->getHeaders()['x-fb-ads-insights-throttle'] results in a chopped value {"app_id_util_pct".

The fix will handle the transformation of the header fields in a valid way. 

Similar to this fix:
https://github.com/facebook/facebook-php-ads-sdk/pull/241/files