### PR TITLE
Fixed invalid format handling of headers[x-fb-ads-insights-throttle]

### DIFF
--- a/src/Facebook/Http/GraphRawResponse.php
+++ b/src/Facebook/Http/GraphRawResponse.php
@@ -129,7 +129,7 @@ class GraphRawResponse
             if (strpos($line, ': ') === false) {
                 $this->setHttpResponseCodeFromHeader($line);
             } else {
-                list($key, $value) = explode(': ', $line);
+                list($key, $value) = explode(': ', $line, 2);
                 $this->headers[$key] = $value;
             }
         }

--- a/tests/Http/GraphRawResponseTest.php
+++ b/tests/Http/GraphRawResponseTest.php
@@ -48,6 +48,9 @@ HEADER;
         'Access-Control-Allow-Origin' => '*',
     ];
 
+    protected $jsonFakeHeader = 'x-fb-ads-insights-throttle: {"app_id_util_pct": 0.00,"acc_id_util_pct": 0.00}';
+    protected $jsonFakeHeaderAsArray = ['x-fb-ads-insights-throttle' => '{"app_id_util_pct": 0.00,"acc_id_util_pct": 0.00}'];
+
     public function testCanSetTheHeadersFromAnArray()
     {
         $myHeaders = [
@@ -78,5 +81,13 @@ HEADER;
 
         $this->assertEquals($this->fakeHeadersAsArray, $headers);
         $this->assertEquals(200, $httpResponseCode);
+    }
+
+    public function testCanTransformJsonHeaderValues()
+    {
+        $response = new GraphRawResponse($this->jsonFakeHeader, '');
+        $headers = $response->getHeaders();
+
+        $this->assertEquals($this->jsonFakeHeaderAsArray['x-fb-ads-insights-throttle'], $headers['x-fb-ads-insights-throttle']);
     }
 }


### PR DESCRIPTION


The raw response header field "X-FB-Ads-Insights-Throttle" contains a json value { "app_id_util_pct": 100, "acc_id_util_pct": 10 }

Calling $response->getHeaders()['x-fb-ads-insights-throttle'] results in a chopped value {"app_id_util_pct".

The fix will handle the transformation of the header fields in a valid way.

Similar to this fix:
https://github.com/facebook/facebook-php-ads-sdk/pull/241/files

Relates to https://github.com/facebook/php-graph-sdk/pull/678