### PR TITLE
Update CSPRNG factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "guzzlehttp/guzzle": "~5.0"
     },
     "suggest": {
+        "paragonie/random_compat": "Provides a better CSPRNG option in PHP 5",
         "guzzlehttp/guzzle": "Allows for implementation of the Guzzle HTTP client"
     },
     "autoload": {

--- a/src/Facebook/PseudoRandomString/RandomBytesPseudoRandomStringGenerator.php
+++ b/src/Facebook/PseudoRandomString/RandomBytesPseudoRandomStringGenerator.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright 2016 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\PseudoRandomString;
+
+use Facebook\Exceptions\FacebookSDKException;
+
+class RandomBytesPseudoRandomStringGenerator implements PseudoRandomStringGeneratorInterface
+{
+    use PseudoRandomStringGeneratorTrait;
+
+    /**
+     * @const string The error message when generating the string fails.
+     */
+    const ERROR_MESSAGE = 'Unable to generate a cryptographically secure pseudo-random string from random_bytes(). ';
+
+    /**
+     * @throws FacebookSDKException
+     */
+    public function __construct()
+    {
+        if (!function_exists('random_bytes')) {
+            throw new FacebookSDKException(
+                static::ERROR_MESSAGE .
+                'The function random_bytes() does not exist.'
+            );
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPseudoRandomString($length)
+    {
+        $this->validateLength($length);
+
+        return $this->binToHex(random_bytes($length), $length);
+    }
+}

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -191,6 +191,25 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         new Facebook($config);
     }
 
+    public function testRandomBytesCsprgCanBeForced()
+    {
+        if (!function_exists('random_bytes')) {
+            $this->markTestSkipped(
+                'Must have PHP 7 or paragonie/random_compat installed to test random_bytes().'
+            );
+        }
+
+        $config = array_merge($this->config, [
+            'persistent_data_handler' => 'memory', // To keep session errors from happening
+            'pseudo_random_string_generator' => 'random_bytes'
+        ]);
+        $fb = new Facebook($config);
+        $this->assertInstanceOf(
+            'Facebook\PseudoRandomString\RandomBytesPseudoRandomStringGenerator',
+            $fb->getRedirectLoginHelper()->getPseudoRandomStringGenerator()
+        );
+    }
+
     public function testMcryptCsprgCanBeForced()
     {
         if (!function_exists('mcrypt_create_iv')) {

--- a/tests/PseudoRandomString/PseudoRandomStringFactoryTest.php
+++ b/tests/PseudoRandomString/PseudoRandomStringFactoryTest.php
@@ -35,9 +35,9 @@ class PseudoRandomStringFactoryTest extends PHPUnit_Framework_TestCase
      * @param mixed  $handler
      * @param string $expected
      *
-     * @dataProvider httpClientsProvider
+     * @dataProvider csprngProvider
      */
-    public function testCreateHttpClient($handler, $expected)
+    public function testCsprng($handler, $expected)
     {
         $pseudoRandomStringGenerator = PseudoRandomStringGeneratorFactory::createPseudoRandomStringGenerator($handler);
 
@@ -48,11 +48,14 @@ class PseudoRandomStringFactoryTest extends PHPUnit_Framework_TestCase
     /**
      * @return array
      */
-    public function httpClientsProvider()
+    public function csprngProvider()
     {
         $providers = [
           [null, self::COMMON_INTERFACE],
         ];
+        if (function_exists('random_bytes')) {
+            $providers[] = ['random_bytes', self::COMMON_NAMESPACE . 'RandomBytesPseudoRandomStringGenerator'];
+        }
         if (function_exists('mcrypt_create_iv')) {
             $providers[] = ['mcrypt', self::COMMON_NAMESPACE . 'McryptPseudoRandomStringGenerator'];
         }

--- a/tests/PseudoRandomString/RandomBytesPseudoRandomStringGeneratorTest.php
+++ b/tests/PseudoRandomString/RandomBytesPseudoRandomStringGeneratorTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright 2016 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\Tests\PseudoRandomString;
+
+use Facebook\PseudoRandomString\RandomBytesPseudoRandomStringGenerator;
+
+class RandomBytesPseudoRandomStringGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCanGenerateRandomStringOfArbitraryLength()
+    {
+        if (!function_exists('random_bytes')) {
+            $this->markTestSkipped(
+                'Must have PHP 7 or paragonie/random_compat installed to test random_bytes().'
+            );
+        }
+
+        $csprng = new RandomBytesPseudoRandomStringGenerator;
+        $randomString = $csprng->getPseudoRandomString(10);
+
+        $this->assertEquals(1, preg_match('/^([0-9a-f]+)$/', $randomString));
+        $this->assertEquals(10, strlen($randomString));
+    }
+}


### PR DESCRIPTION
Adds a check for PHP 7 CSPRNG first to keep mcrypt deprecation messages from appearing in PHP 7.1.

Addresses #663.