### PR TITLE
Update SignedRequest.php

### DIFF
--- a/src/Facebook/SignedRequest.php
+++ b/src/Facebook/SignedRequest.php
@@ -211,7 +211,7 @@ class SignedRequest
         $payload = $this->base64UrlDecode($encodedPayload);
 
         if ($payload) {
-            $payload = json_decode($payload, true);
+            $payload = json_decode($payload, true, 2, JSON_BIGINT_AS_STRING);
         }
 
         if (!is_array($payload)) {


### PR DESCRIPTION
Changing for representation "payment_id" as string, because "payment_id" has 15 decimal digits and float type in php has 14 decimal digits so 1 digit is lost