### PR TITLE
Enhancement: Keep packages sorted without specifying --sort-packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,17 @@
             "homepage": "https://github.com/facebook/php-graph-sdk/contributors"
         }
     ],
+    "config": {
+        "sort-packages": true
+    },
     "require": {
         "php": "^5.6 || ^7.0",
         "paragonie/random_compat": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.5",
+        "guzzlehttp/guzzle": "~5.0",
         "mockery/mockery": "~0.8",
-        "guzzlehttp/guzzle": "~5.0"
+        "phpunit/phpunit": "^5.7.5"
     },
     "suggest": {
         "guzzlehttp/guzzle": "Allows for implementation of the Guzzle HTTP client"


### PR DESCRIPTION
This PR

* [x] keeps packages in `composer.json` sorted without the need to specify the `--sort-packages` flag when requiring packages

💁‍♂️ For reference, see https://getcomposer.org/doc/06-config.md#sort-packages.