### PR TITLE
Fix: Run build on PHP7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,3 @@ install:
 script:
   - vendor/bin/phpcs
   - vendor/bin/phpunit --coverage-text --exclude-group integration
-
-matrix:
-  allow_failures:
-    - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 php:
   - 5.6
   - 7.0
-  - 7.1.0RC3
+  - 7.1
   - hhvm
 
 sudo: false
@@ -25,4 +25,4 @@ script:
 
 matrix:
   allow_failures:
-    - php: 7.1.0RC3
+    - php: 7.1


### PR DESCRIPTION
This PR

* [x] adjusts `.travis.yml` to run a build on PHP7.1 (instead of the RC)
* [x] requires builds on PHP7.1 to pass