### PR TITLE
Enhancement: Allow to finish the builds as soon as possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,6 @@ script:
   - vendor/bin/phpunit --coverage-text --exclude-group integration
 
 matrix:
+  fast_finish: true
   allow_failures:
     - php: 7.1.0RC3


### PR DESCRIPTION
This PR

* [x] allows builds to finish as fast as possible

💁‍♂️ For reference, see https://docs.travis-ci.com/user/customizing-the-build#Fast-Finishing:

> If some rows in the build matrix are allowed to fail, the build won’t be marked as finished until they have completed.
>
>To set the build to finish as soon as possible, add `fast_finish: true` to the `matrix` section of your `.travis.yml` like this:
>
>```yml
>matrix:
>  fast_finish: true
>```
>Now, a build will finish as soon as a job has failed, or when the only jobs left allow failures.