### PR TITLE
Fix: Remove useless override

### DIFF
--- a/src/Facebook/GraphNodes/GraphObjectFactory.php
+++ b/src/Facebook/GraphNodes/GraphObjectFactory.php
@@ -60,18 +60,6 @@ class GraphObjectFactory extends GraphNodeFactory
     }
 
     /**
-     * Convenience method for creating a GraphEvent collection.
-     *
-     * @return GraphEvent
-     *
-     * @throws FacebookSDKException
-     */
-    public function makeGraphEvent()
-    {
-        return $this->makeGraphNode(static::BASE_GRAPH_OBJECT_PREFIX . 'GraphEvent');
-    }
-
-    /**
      * Tries to convert a FacebookResponse entity into a GraphEdge.
      *
      * @param string|null $subclassName The GraphNode sub class to cast the list items to.


### PR DESCRIPTION
This PR

* [x] removes a method that needlessly overrides a method in the parent class

💁‍♂️ The code is exactly the same, see [`Facebook\GraphNodes\GraphNodeFactory::makeGraphEvent()`](https://github.com/facebook/php-graph-sdk/blob/master/src/Facebook/GraphNodes/GraphNodeFactory.php#L158-L168).