### PR TITLE
Fix: Use class keyword

### DIFF
--- a/src/Facebook/GraphNodes/GraphAchievement.php
+++ b/src/Facebook/GraphNodes/GraphAchievement.php
@@ -34,8 +34,8 @@ class GraphAchievement extends GraphNode
      * @var array Maps object key names to Graph object types.
      */
     protected static $graphObjectMap = [
-        'from' => '\Facebook\GraphNodes\GraphUser',
-        'application' => '\Facebook\GraphNodes\GraphApplication',
+        'from' => GraphUser::class,
+        'application' => GraphApplication::class,
     ];
 
     /**

--- a/src/Facebook/GraphNodes/GraphAlbum.php
+++ b/src/Facebook/GraphNodes/GraphAlbum.php
@@ -35,8 +35,8 @@ class GraphAlbum extends GraphNode
      * @var array Maps object key names to Graph object types.
      */
     protected static $graphObjectMap = [
-        'from' => '\Facebook\GraphNodes\GraphUser',
-        'place' => '\Facebook\GraphNodes\GraphPage',
+        'from' => GraphUser::class,
+        'place' => GraphPage::class,
     ];
 
     /**

--- a/src/Facebook/GraphNodes/GraphEvent.php
+++ b/src/Facebook/GraphNodes/GraphEvent.php
@@ -34,10 +34,10 @@ class GraphEvent extends GraphNode
      * @var array Maps object key names to GraphNode types.
      */
     protected static $graphObjectMap = [
-        'cover' => '\Facebook\GraphNodes\GraphCoverPhoto',
-        'place' => '\Facebook\GraphNodes\GraphPage',
-        'picture' => '\Facebook\GraphNodes\GraphPicture',
-        'parent_group' => '\Facebook\GraphNodes\GraphGroup',
+        'cover' => GraphCoverPhoto::class,
+        'place' => GraphPage::class,
+        'picture' => GraphPicture::class,
+        'parent_group' => GraphGroup::class,
     ];
 
     /**

--- a/src/Facebook/GraphNodes/GraphGroup.php
+++ b/src/Facebook/GraphNodes/GraphGroup.php
@@ -34,8 +34,8 @@ class GraphGroup extends GraphNode
      * @var array Maps object key names to GraphNode types.
      */
     protected static $graphObjectMap = [
-        'cover' => '\Facebook\GraphNodes\GraphCoverPhoto',
-        'venue' => '\Facebook\GraphNodes\GraphLocation',
+        'cover' => GraphCoverPhoto::class,
+        'venue' => GraphLocation::class,
     ];
 
     /**

--- a/src/Facebook/GraphNodes/GraphNodeFactory.php
+++ b/src/Facebook/GraphNodes/GraphNodeFactory.php
@@ -45,12 +45,12 @@ class GraphNodeFactory
     /**
      * @const string The base graph object class.
      */
-    const BASE_GRAPH_NODE_CLASS = '\Facebook\GraphNodes\GraphNode';
+    const BASE_GRAPH_NODE_CLASS = GraphNode::class;
 
     /**
      * @const string The base graph edge class.
      */
-    const BASE_GRAPH_EDGE_CLASS = '\Facebook\GraphNodes\GraphEdge';
+    const BASE_GRAPH_EDGE_CLASS = GraphEdge::class;
 
     /**
      * @const string The graph object prefix.

--- a/src/Facebook/GraphNodes/GraphObjectFactory.php
+++ b/src/Facebook/GraphNodes/GraphObjectFactory.php
@@ -38,12 +38,12 @@ class GraphObjectFactory extends GraphNodeFactory
     /**
      * @const string The base graph object class.
      */
-    const BASE_GRAPH_NODE_CLASS = '\Facebook\GraphNodes\GraphObject';
+    const BASE_GRAPH_NODE_CLASS = GraphObject::class;
 
     /**
      * @const string The base graph edge class.
      */
-    const BASE_GRAPH_EDGE_CLASS = '\Facebook\GraphNodes\GraphList';
+    const BASE_GRAPH_EDGE_CLASS = GraphList::class;
 
     /**
      * Tries to convert a FacebookResponse entity into a GraphNode.

--- a/src/Facebook/GraphNodes/GraphPage.php
+++ b/src/Facebook/GraphNodes/GraphPage.php
@@ -34,11 +34,11 @@ class GraphPage extends GraphNode
      * @var array Maps object key names to Graph object types.
      */
     protected static $graphObjectMap = [
-        'best_page' => '\Facebook\GraphNodes\GraphPage',
-        'global_brand_parent_page' => '\Facebook\GraphNodes\GraphPage',
-        'location' => '\Facebook\GraphNodes\GraphLocation',
-        'cover' => '\Facebook\GraphNodes\GraphCoverPhoto',
-        'picture' => '\Facebook\GraphNodes\GraphPicture',
+        'best_page' => GraphPage::class,
+        'global_brand_parent_page' => GraphPage::class,
+        'location' => GraphLocation::class,
+        'cover' => GraphCoverPhoto::class,
+        'picture' => GraphPicture::class,
     ];
 
     /**

--- a/src/Facebook/GraphNodes/GraphUser.php
+++ b/src/Facebook/GraphNodes/GraphUser.php
@@ -34,10 +34,10 @@ class GraphUser extends GraphNode
      * @var array Maps object key names to Graph object types.
      */
     protected static $graphObjectMap = [
-        'hometown' => '\Facebook\GraphNodes\GraphPage',
-        'location' => '\Facebook\GraphNodes\GraphPage',
-        'significant_other' => '\Facebook\GraphNodes\GraphUser',
-        'picture' => '\Facebook\GraphNodes\GraphPicture',
+        'hometown' => GraphPage::class,
+        'location' => GraphPage::class,
+        'significant_other' => GraphUser::class,
+        'picture' => GraphPicture::class,
     ];
 
     /**

--- a/tests/Authentication/AccessTokenMetadataTest.php
+++ b/tests/Authentication/AccessTokenMetadataTest.php
@@ -58,8 +58,8 @@ class AccessTokenMetadataTest extends \PHPUnit_Framework_TestCase
         $expires = $metadata->getExpiresAt();
         $issuedAt = $metadata->getIssuedAt();
 
-        $this->assertInstanceOf('DateTime', $expires);
-        $this->assertInstanceOf('DateTime', $issuedAt);
+        $this->assertInstanceOf(\DateTime::class, $expires);
+        $this->assertInstanceOf(\DateTime::class, $issuedAt);
     }
 
     public function testAllTheGettersReturnTheProperValue()

--- a/tests/Authentication/OAuth2ClientTest.php
+++ b/tests/Authentication/OAuth2ClientTest.php
@@ -26,6 +26,8 @@ namespace Facebook\Tests\Authentication;
 use Facebook\Facebook;
 use Facebook\FacebookApp;
 use Facebook\Authentication\OAuth2Client;
+use Facebook\Authentication\AccessTokenMetadata;
+use Facebook\Authentication\AccessToken;
 
 class OAuth2ClientTest extends \PHPUnit_Framework_TestCase
 {
@@ -58,7 +60,7 @@ class OAuth2ClientTest extends \PHPUnit_Framework_TestCase
 
         $metadata = $this->oauth->debugToken('baz_token');
 
-        $this->assertInstanceOf('Facebook\Authentication\AccessTokenMetadata', $metadata);
+        $this->assertInstanceOf(AccessTokenMetadata::class, $metadata);
         $this->assertEquals('444', $metadata->getUserId());
 
         $expectedParams = [
@@ -103,7 +105,7 @@ class OAuth2ClientTest extends \PHPUnit_Framework_TestCase
 
         $accessToken = $this->oauth->getAccessTokenFromCode('bar_code', 'foo_uri');
 
-        $this->assertInstanceOf('Facebook\Authentication\AccessToken', $accessToken);
+        $this->assertInstanceOf(AccessToken::class, $accessToken);
         $this->assertEquals('my_access_token', $accessToken->getValue());
 
         $expectedParams = [

--- a/tests/Exceptions/FacebookResponseExceptionTest.php
+++ b/tests/Exceptions/FacebookResponseExceptionTest.php
@@ -27,6 +27,12 @@ use Facebook\FacebookApp;
 use Facebook\FacebookRequest;
 use Facebook\FacebookResponse;
 use Facebook\Exceptions\FacebookResponseException;
+use Facebook\Exceptions\FacebookAuthenticationException;
+use Facebook\Exceptions\FacebookServerException;
+use Facebook\Exceptions\FacebookThrottleException;
+use Facebook\Exceptions\FacebookAuthorizationException;
+use Facebook\Exceptions\FacebookClientException;
+use Facebook\Exceptions\FacebookOtherException;
 
 class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
 {
@@ -54,7 +60,7 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
 
         $response = new FacebookResponse($this->request, json_encode($params), 401);
         $exception = FacebookResponseException::create($response);
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthenticationException', $exception->getPrevious());
+        $this->assertInstanceOf(FacebookAuthenticationException::class, $exception->getPrevious());
         $this->assertEquals(100, $exception->getCode());
         $this->assertEquals(0, $exception->getSubErrorCode());
         $this->assertEquals('exception', $exception->getErrorType());
@@ -65,13 +71,13 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
         $params['error']['code'] = 102;
         $response = new FacebookResponse($this->request, json_encode($params), 401);
         $exception = FacebookResponseException::create($response);
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthenticationException', $exception->getPrevious());
+        $this->assertInstanceOf(FacebookAuthenticationException::class, $exception->getPrevious());
         $this->assertEquals(102, $exception->getCode());
 
         $params['error']['code'] = 190;
         $response = new FacebookResponse($this->request, json_encode($params), 401);
         $exception = FacebookResponseException::create($response);
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthenticationException', $exception->getPrevious());
+        $this->assertInstanceOf(FacebookAuthenticationException::class, $exception->getPrevious());
         $this->assertEquals(190, $exception->getCode());
 
         $params['error']['type'] = 'OAuthException';
@@ -79,31 +85,31 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
         $params['error']['error_subcode'] = 458;
         $response = new FacebookResponse($this->request, json_encode($params), 401);
         $exception = FacebookResponseException::create($response);
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthenticationException', $exception->getPrevious());
+        $this->assertInstanceOf(FacebookAuthenticationException::class, $exception->getPrevious());
         $this->assertEquals(458, $exception->getSubErrorCode());
 
         $params['error']['error_subcode'] = 460;
         $response = new FacebookResponse($this->request, json_encode($params), 401);
         $exception = FacebookResponseException::create($response);
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthenticationException', $exception->getPrevious());
+        $this->assertInstanceOf(FacebookAuthenticationException::class, $exception->getPrevious());
         $this->assertEquals(460, $exception->getSubErrorCode());
 
         $params['error']['error_subcode'] = 463;
         $response = new FacebookResponse($this->request, json_encode($params), 401);
         $exception = FacebookResponseException::create($response);
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthenticationException', $exception->getPrevious());
+        $this->assertInstanceOf(FacebookAuthenticationException::class, $exception->getPrevious());
         $this->assertEquals(463, $exception->getSubErrorCode());
 
         $params['error']['error_subcode'] = 467;
         $response = new FacebookResponse($this->request, json_encode($params), 401);
         $exception = FacebookResponseException::create($response);
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthenticationException', $exception->getPrevious());
+        $this->assertInstanceOf(FacebookAuthenticationException::class, $exception->getPrevious());
         $this->assertEquals(467, $exception->getSubErrorCode());
 
         $params['error']['error_subcode'] = 0;
         $response = new FacebookResponse($this->request, json_encode($params), 401);
         $exception = FacebookResponseException::create($response);
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthenticationException', $exception->getPrevious());
+        $this->assertInstanceOf(FacebookAuthenticationException::class, $exception->getPrevious());
         $this->assertEquals(0, $exception->getSubErrorCode());
     }
 
@@ -120,7 +126,7 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
 
         $response = new FacebookResponse($this->request, json_encode($params), 500);
         $exception = FacebookResponseException::create($response);
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookServerException', $exception->getPrevious());
+        $this->assertInstanceOf(FacebookServerException::class, $exception->getPrevious());
         $this->assertEquals(1, $exception->getCode());
         $this->assertEquals(0, $exception->getSubErrorCode());
         $this->assertEquals('exception', $exception->getErrorType());
@@ -131,7 +137,7 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
         $params['error']['code'] = 2;
         $response = new FacebookResponse($this->request, json_encode($params), 500);
         $exception = FacebookResponseException::create($response);
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookServerException', $exception->getPrevious());
+        $this->assertInstanceOf(FacebookServerException::class, $exception->getPrevious());
         $this->assertEquals(2, $exception->getCode());
     }
 
@@ -147,7 +153,7 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
         ];
         $response = new FacebookResponse($this->request, json_encode($params), 401);
         $exception = FacebookResponseException::create($response);
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookThrottleException', $exception->getPrevious());
+        $this->assertInstanceOf(FacebookThrottleException::class, $exception->getPrevious());
         $this->assertEquals(4, $exception->getCode());
         $this->assertEquals(0, $exception->getSubErrorCode());
         $this->assertEquals('exception', $exception->getErrorType());
@@ -158,13 +164,13 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
         $params['error']['code'] = 17;
         $response = new FacebookResponse($this->request, json_encode($params), 401);
         $exception = FacebookResponseException::create($response);
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookThrottleException', $exception->getPrevious());
+        $this->assertInstanceOf(FacebookThrottleException::class, $exception->getPrevious());
         $this->assertEquals(17, $exception->getCode());
 
         $params['error']['code'] = 341;
         $response = new FacebookResponse($this->request, json_encode($params), 401);
         $exception = FacebookResponseException::create($response);
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookThrottleException', $exception->getPrevious());
+        $this->assertInstanceOf(FacebookThrottleException::class, $exception->getPrevious());
         $this->assertEquals(341, $exception->getCode());
     }
 
@@ -180,7 +186,7 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
         ];
         $response = new FacebookResponse($this->request, json_encode($params), 401);
         $exception = FacebookResponseException::create($response);
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthenticationException', $exception->getPrevious());
+        $this->assertInstanceOf(FacebookAuthenticationException::class, $exception->getPrevious());
         $this->assertEquals(230, $exception->getCode());
         $this->assertEquals(459, $exception->getSubErrorCode());
         $this->assertEquals('exception', $exception->getErrorType());
@@ -191,7 +197,7 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
         $params['error']['error_subcode'] = 464;
         $response = new FacebookResponse($this->request, json_encode($params), 401);
         $exception = FacebookResponseException::create($response);
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthenticationException', $exception->getPrevious());
+        $this->assertInstanceOf(FacebookAuthenticationException::class, $exception->getPrevious());
         $this->assertEquals(464, $exception->getSubErrorCode());
     }
 
@@ -207,7 +213,7 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
         ];
         $response = new FacebookResponse($this->request, json_encode($params), 401);
         $exception = FacebookResponseException::create($response);
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthorizationException', $exception->getPrevious());
+        $this->assertInstanceOf(FacebookAuthorizationException::class, $exception->getPrevious());
         $this->assertEquals(10, $exception->getCode());
         $this->assertEquals(0, $exception->getSubErrorCode());
         $this->assertEquals('exception', $exception->getErrorType());
@@ -218,19 +224,19 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
         $params['error']['code'] = 200;
         $response = new FacebookResponse($this->request, json_encode($params), 401);
         $exception = FacebookResponseException::create($response);
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthorizationException', $exception->getPrevious());
+        $this->assertInstanceOf(FacebookAuthorizationException::class, $exception->getPrevious());
         $this->assertEquals(200, $exception->getCode());
 
         $params['error']['code'] = 250;
         $response = new FacebookResponse($this->request, json_encode($params), 401);
         $exception = FacebookResponseException::create($response);
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthorizationException', $exception->getPrevious());
+        $this->assertInstanceOf(FacebookAuthorizationException::class, $exception->getPrevious());
         $this->assertEquals(250, $exception->getCode());
 
         $params['error']['code'] = 299;
         $response = new FacebookResponse($this->request, json_encode($params), 401);
         $exception = FacebookResponseException::create($response);
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthorizationException', $exception->getPrevious());
+        $this->assertInstanceOf(FacebookAuthorizationException::class, $exception->getPrevious());
         $this->assertEquals(299, $exception->getCode());
     }
 
@@ -246,7 +252,7 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
         ];
         $response = new FacebookResponse($this->request, json_encode($params), 401);
         $exception = FacebookResponseException::create($response);
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookClientException', $exception->getPrevious());
+        $this->assertInstanceOf(FacebookClientException::class, $exception->getPrevious());
         $this->assertEquals(506, $exception->getCode());
         $this->assertEquals(0, $exception->getSubErrorCode());
         $this->assertEquals('exception', $exception->getErrorType());
@@ -267,7 +273,7 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
         ];
         $response = new FacebookResponse($this->request, json_encode($params), 200);
         $exception = FacebookResponseException::create($response);
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookOtherException', $exception->getPrevious());
+        $this->assertInstanceOf(FacebookOtherException::class, $exception->getPrevious());
         $this->assertEquals(42, $exception->getCode());
         $this->assertEquals(0, $exception->getSubErrorCode());
         $this->assertEquals('feature', $exception->getErrorType());

--- a/tests/FacebookAppTest.php
+++ b/tests/FacebookAppTest.php
@@ -24,6 +24,7 @@
 namespace Facebook\Tests;
 
 use Facebook\FacebookApp;
+use Facebook\Authentication\AccessToken;
 
 class FacebookAppTest extends \PHPUnit_Framework_TestCase
 {
@@ -51,7 +52,7 @@ class FacebookAppTest extends \PHPUnit_Framework_TestCase
     {
         $accessToken = $this->app->getAccessToken();
 
-        $this->assertInstanceOf('Facebook\Authentication\AccessToken', $accessToken);
+        $this->assertInstanceOf(AccessToken::class, $accessToken);
         $this->assertEquals('id|secret', (string)$accessToken);
     }
 
@@ -59,7 +60,7 @@ class FacebookAppTest extends \PHPUnit_Framework_TestCase
     {
         $newApp = unserialize(serialize($this->app));
 
-        $this->assertInstanceOf('Facebook\FacebookApp', $newApp);
+        $this->assertInstanceOf(FacebookApp::class, $newApp);
         $this->assertEquals('id', $newApp->getId());
         $this->assertEquals('secret', $newApp->getSecret());
     }

--- a/tests/FacebookBatchResponseTest.php
+++ b/tests/FacebookBatchResponseTest.php
@@ -28,6 +28,7 @@ use Facebook\FacebookRequest;
 use Facebook\FacebookResponse;
 use Facebook\FacebookBatchRequest;
 use Facebook\FacebookBatchResponse;
+use Facebook\GraphNodes\GraphNode;
 
 class FacebookBatchResponseTest extends \PHPUnit_Framework_TestCase
 {
@@ -80,12 +81,12 @@ class FacebookBatchResponseTest extends \PHPUnit_Framework_TestCase
 
         // Single Graph object.
         $this->assertFalse($decodedResponses[0]->isError(), 'Did not expect Response to return an error for single Graph object.');
-        $this->assertInstanceOf('Facebook\GraphNodes\GraphNode', $decodedResponses[0]->getGraphNode());
+        $this->assertInstanceOf(GraphNode::class, $decodedResponses[0]->getGraphNode());
         // Paginated list of Graph objects.
         $this->assertFalse($decodedResponses[1]->isError(), 'Did not expect Response to return an error for paginated list of Graph objects.');
         $graphEdge = $decodedResponses[1]->getGraphEdge();
-        $this->assertInstanceOf('Facebook\GraphNodes\GraphNode', $graphEdge[0]);
-        $this->assertInstanceOf('Facebook\GraphNodes\GraphNode', $graphEdge[1]);
+        $this->assertInstanceOf(GraphNode::class, $graphEdge[0]);
+        $this->assertInstanceOf(GraphNode::class, $graphEdge[1]);
     }
 
     public function testABatchResponseCanBeIteratedOver()
@@ -103,11 +104,11 @@ class FacebookBatchResponseTest extends \PHPUnit_Framework_TestCase
         ]);
         $batchResponse = new FacebookBatchResponse($batchRequest, $response);
 
-        $this->assertInstanceOf('IteratorAggregate', $batchResponse);
+        $this->assertInstanceOf(\IteratorAggregate::class, $batchResponse);
 
         foreach ($batchResponse as $key => $responseEntity) {
             $this->assertTrue(in_array($key, ['req_one', 'req_two', 'req_three']));
-            $this->assertInstanceOf('Facebook\FacebookResponse', $responseEntity);
+            $this->assertInstanceOf(FacebookResponse::class, $responseEntity);
         }
     }
 
@@ -129,8 +130,8 @@ class FacebookBatchResponseTest extends \PHPUnit_Framework_TestCase
         $batchRequest = new FacebookBatchRequest($this->app, $requests);
         $batchResponse = new FacebookBatchResponse($batchRequest, $response);
 
-        $this->assertInstanceOf('Facebook\FacebookResponse', $batchResponse[0]);
-        $this->assertInstanceOf('Facebook\FacebookRequest', $batchResponse[0]->getRequest());
+        $this->assertInstanceOf(FacebookResponse::class, $batchResponse[0]);
+        $this->assertInstanceOf(FacebookRequest::class, $batchResponse[0]->getRequest());
         $this->assertEquals('foo_token_one', $batchResponse[0]->getAccessToken());
         $this->assertEquals('foo_token_two', $batchResponse[1]->getAccessToken());
         $this->assertEquals('foo_token_three', $batchResponse[2]->getAccessToken());

--- a/tests/FacebookClientTest.php
+++ b/tests/FacebookClientTest.php
@@ -36,6 +36,9 @@ use Facebook\HttpClients\FacebookGuzzleHttpClient;
 use Facebook\HttpClients\FacebookStreamHttpClient;
 use Facebook\Tests\Fixtures\MyFooBatchClientHandler;
 use Facebook\Tests\Fixtures\MyFooClientHandler;
+use Facebook\FacebookResponse;
+use Facebook\FacebookBatchResponse;
+use Facebook\GraphNodes\GraphNode;
 
 class FacebookClientTest extends \PHPUnit_Framework_TestCase
 {
@@ -71,7 +74,7 @@ class FacebookClientTest extends \PHPUnit_Framework_TestCase
         $client = new FacebookClient($handler);
         $httpHandler = $client->getHttpClientHandler();
 
-        $this->assertInstanceOf('Facebook\Tests\Fixtures\MyFooClientHandler', $httpHandler);
+        $this->assertInstanceOf(MyFooClientHandler::class, $httpHandler);
     }
 
     public function testTheHttpClientWillFallbackToDefault()
@@ -80,9 +83,9 @@ class FacebookClientTest extends \PHPUnit_Framework_TestCase
         $httpHandler = $client->getHttpClientHandler();
 
         if (function_exists('curl_init')) {
-            $this->assertInstanceOf('Facebook\HttpClients\FacebookCurlHttpClient', $httpHandler);
+            $this->assertInstanceOf(FacebookCurlHttpClient::class, $httpHandler);
         } else {
-            $this->assertInstanceOf('Facebook\HttpClients\FacebookStreamHttpClient', $httpHandler);
+            $this->assertInstanceOf(FacebookStreamHttpClient::class, $httpHandler);
         }
     }
 
@@ -126,7 +129,7 @@ class FacebookClientTest extends \PHPUnit_Framework_TestCase
         $fbRequest = new FacebookRequest($this->fbApp, 'token', 'GET', '/foo');
         $response = $this->fbClient->sendRequest($fbRequest);
 
-        $this->assertInstanceOf('Facebook\FacebookResponse', $response);
+        $this->assertInstanceOf(FacebookResponse::class, $response);
         $this->assertEquals(200, $response->getHttpStatusCode());
         $this->assertEquals('{"data":[{"id":"123","name":"Foo"},{"id":"1337","name":"Bar"}]}', $response->getBody());
     }
@@ -142,7 +145,7 @@ class FacebookClientTest extends \PHPUnit_Framework_TestCase
         $fbBatchClient = new FacebookClient(new MyFooBatchClientHandler());
         $response = $fbBatchClient->sendBatchRequest($fbBatchRequest);
 
-        $this->assertInstanceOf('Facebook\FacebookBatchResponse', $response);
+        $this->assertInstanceOf(FacebookBatchResponse::class, $response);
         $this->assertEquals('GET', $response[0]->getRequest()->getMethod());
         $this->assertEquals('POST', $response[1]->getRequest()->getMethod());
     }
@@ -197,7 +200,7 @@ class FacebookClientTest extends \PHPUnit_Framework_TestCase
 
     public function testAFacebookRequestValidatesTheAccessTokenWhenOneIsNotProvided()
     {
-        $this->setExpectedException('Facebook\Exceptions\FacebookSDKException');
+        $this->setExpectedException(FacebookSDKException::class);
 
         $fbRequest = new FacebookRequest($this->fbApp, null, 'GET', '/foo');
         $this->fbClient->sendRequest($fbRequest);
@@ -240,7 +243,7 @@ class FacebookClientTest extends \PHPUnit_Framework_TestCase
         );
         $graphNode = static::$testFacebookClient->sendRequest($request)->getGraphNode();
 
-        $this->assertInstanceOf('Facebook\GraphNodes\GraphNode', $graphNode);
+        $this->assertInstanceOf(GraphNode::class, $graphNode);
         $this->assertNotNull($graphNode->getField('id'));
         $this->assertEquals('Foo Phpunit User', $graphNode->getField('name'));
 

--- a/tests/FacebookRequestTest.php
+++ b/tests/FacebookRequestTest.php
@@ -35,7 +35,7 @@ class FacebookRequestTest extends \PHPUnit_Framework_TestCase
         $app = new FacebookApp('123', 'foo_secret');
         $request = new FacebookRequest($app);
 
-        $this->assertInstanceOf('Facebook\FacebookRequest', $request);
+        $this->assertInstanceOf(FacebookRequest::class, $request);
     }
 
     /**

--- a/tests/FacebookResponseTest.php
+++ b/tests/FacebookResponseTest.php
@@ -26,6 +26,8 @@ namespace Facebook\Tests;
 use Facebook\FacebookApp;
 use Facebook\FacebookRequest;
 use Facebook\FacebookResponse;
+use Facebook\GraphNodes\GraphNode;
+use Facebook\Exceptions\FacebookResponseException;
 
 class FacebookResponseTest extends \PHPUnit_Framework_TestCase
 {
@@ -79,7 +81,7 @@ class FacebookResponseTest extends \PHPUnit_Framework_TestCase
             'id' => '123',
             'name' => 'Foo',
         ], $decodedResponse);
-        $this->assertInstanceOf('Facebook\GraphNodes\GraphNode', $graphNode);
+        $this->assertInstanceOf(GraphNode::class, $graphNode);
     }
 
     public function testASuccessfulJsonResponseWillBeDecodedToAGraphEdge()
@@ -90,8 +92,8 @@ class FacebookResponseTest extends \PHPUnit_Framework_TestCase
         $graphEdge = $response->getGraphEdge();
 
         $this->assertFalse($response->isError(), 'Did not expect Response to return an error.');
-        $this->assertInstanceOf('Facebook\GraphNodes\GraphNode', $graphEdge[0]);
-        $this->assertInstanceOf('Facebook\GraphNodes\GraphNode', $graphEdge[1]);
+        $this->assertInstanceOf(GraphNode::class, $graphEdge[0]);
+        $this->assertInstanceOf(GraphNode::class, $graphEdge[1]);
     }
 
     public function testASuccessfulUrlEncodedKeyValuePairResponseWillBeDecoded()
@@ -116,6 +118,6 @@ class FacebookResponseTest extends \PHPUnit_Framework_TestCase
         $exception = $response->getThrownException();
 
         $this->assertTrue($response->isError(), 'Expected Response to return an error.');
-        $this->assertInstanceOf('Facebook\Exceptions\FacebookResponseException', $exception);
+        $this->assertInstanceOf(FacebookResponseException::class, $exception);
     }
 }

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -32,6 +32,13 @@ use Facebook\Tests\Fixtures\FakeGraphApiForResumableUpload;
 use Facebook\Tests\Fixtures\FooClientInterface;
 use Facebook\Tests\Fixtures\FooPersistentDataInterface;
 use Facebook\Tests\Fixtures\FooUrlDetectionInterface;
+use Facebook\HttpClients\FacebookCurlHttpClient;
+use Facebook\HttpClients\FacebookStreamHttpClient;
+use Facebook\HttpClients\FacebookGuzzleHttpClient;
+use Facebook\PersistentData\FacebookMemoryPersistentDataHandler;
+use Facebook\Url\FacebookUrlDetectionHandler;
+use Facebook\FacebookResponse;
+use Facebook\GraphNodes\GraphUser;
 
 class FacebookTest extends \PHPUnit_Framework_TestCase
 {
@@ -102,7 +109,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         ]);
         $fb = new Facebook($config);
         $this->assertInstanceOf(
-            'Facebook\HttpClients\FacebookCurlHttpClient',
+            FacebookCurlHttpClient::class,
             $fb->getClient()->getHttpClientHandler()
         );
     }
@@ -114,7 +121,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         ]);
         $fb = new Facebook($config);
         $this->assertInstanceOf(
-            'Facebook\HttpClients\FacebookStreamHttpClient',
+            FacebookStreamHttpClient::class,
             $fb->getClient()->getHttpClientHandler()
         );
     }
@@ -126,7 +133,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         ]);
         $fb = new Facebook($config);
         $this->assertInstanceOf(
-            'Facebook\HttpClients\FacebookGuzzleHttpClient',
+            FacebookGuzzleHttpClient::class,
             $fb->getClient()->getHttpClientHandler()
         );
     }
@@ -149,7 +156,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         ]);
         $fb = new Facebook($config);
         $this->assertInstanceOf(
-            'Facebook\PersistentData\FacebookMemoryPersistentDataHandler',
+            FacebookMemoryPersistentDataHandler::class,
             $fb->getRedirectLoginHelper()->getPersistentDataHandler()
         );
     }
@@ -158,7 +165,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
     {
         $expectedException = (PHP_MAJOR_VERSION > 5 && class_exists('TypeError'))
             ? 'TypeError'
-            : 'PHPUnit_Framework_Error';
+            : \PHPUnit_Framework_Error::class;
 
         $this->setExpectedException($expectedException);
 
@@ -171,7 +178,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
     public function testTheUrlHandlerWillDefaultToTheFacebookImplementation()
     {
         $fb = new Facebook($this->config);
-        $this->assertInstanceOf('Facebook\Url\FacebookUrlDetectionHandler', $fb->getUrlDetectionHandler());
+        $this->assertInstanceOf(FacebookUrlDetectionHandler::class, $fb->getUrlDetectionHandler());
     }
 
     public function testAnAccessTokenCanBeSetAsAString()
@@ -180,7 +187,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         $fb->setDefaultAccessToken('foo_token');
         $accessToken = $fb->getDefaultAccessToken();
 
-        $this->assertInstanceOf('Facebook\Authentication\AccessToken', $accessToken);
+        $this->assertInstanceOf(AccessToken::class, $accessToken);
         $this->assertEquals('foo_token', (string)$accessToken);
     }
 
@@ -190,7 +197,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         $fb->setDefaultAccessToken(new AccessToken('bar_token'));
         $accessToken = $fb->getDefaultAccessToken();
 
-        $this->assertInstanceOf('Facebook\Authentication\AccessToken', $accessToken);
+        $this->assertInstanceOf(AccessToken::class, $accessToken);
         $this->assertEquals('bar_token', (string)$accessToken);
     }
 
@@ -235,15 +242,15 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         $fb = new Facebook($config);
 
         $this->assertInstanceOf(
-            'Facebook\Tests\Fixtures\FooClientInterface',
+            FooClientInterface::class,
             $fb->getClient()->getHttpClientHandler()
         );
         $this->assertInstanceOf(
-            'Facebook\Tests\Fixtures\FooPersistentDataInterface',
+            FooPersistentDataInterface::class,
             $fb->getRedirectLoginHelper()->getPersistentDataHandler()
         );
         $this->assertInstanceOf(
-            'Facebook\Tests\Fixtures\FooUrlDetectionInterface',
+            FooUrlDetectionInterface::class,
             $fb->getRedirectLoginHelper()->getUrlDetectionHandler()
         );
     }
@@ -270,16 +277,16 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
                 ]
             ],
             '/1337/photos',
-            '\Facebook\GraphNodes\GraphUser'
+            GraphUser::class
         );
 
         $nextPage = $fb->next($graphEdge);
-        $this->assertInstanceOf('Facebook\GraphNodes\GraphEdge', $nextPage);
-        $this->assertInstanceOf('Facebook\GraphNodes\GraphUser', $nextPage[0]);
+        $this->assertInstanceOf(GraphEdge::class, $nextPage);
+        $this->assertInstanceOf(GraphUser::class, $nextPage[0]);
         $this->assertEquals('Foo', $nextPage[0]['name']);
 
         $lastResponse = $fb->getLastResponse();
-        $this->assertInstanceOf('Facebook\FacebookResponse', $lastResponse);
+        $this->assertInstanceOf(FacebookResponse::class, $lastResponse);
         $this->assertEquals(1337, $lastResponse->getHttpStatusCode());
     }
 

--- a/tests/FileUpload/FacebookResumableUploaderTest.php
+++ b/tests/FileUpload/FacebookResumableUploaderTest.php
@@ -66,7 +66,7 @@ class FacebookResumableUploaderTest extends \PHPUnit_Framework_TestCase
         $uploader = new FacebookResumableUploader($this->fbApp, $this->client, 'access_token', 'v2.4');
         $endpoint = '/me/videos';
         $chunk = $uploader->start($endpoint, $this->file);
-        $this->assertInstanceOf('Facebook\FileUpload\FacebookTransferChunk', $chunk);
+        $this->assertInstanceOf(FacebookTransferChunk::class, $chunk);
         $this->assertEquals('42', $chunk->getUploadSessionId());
         $this->assertEquals('1337', $chunk->getVideoId());
 

--- a/tests/Fixtures/MyFooGraphNode.php
+++ b/tests/Fixtures/MyFooGraphNode.php
@@ -28,6 +28,6 @@ use Facebook\GraphNodes\GraphNode;
 class MyFooGraphNode extends GraphNode
 {
     protected static $graphObjectMap = [
-        'foo_object' => '\Facebook\Tests\Fixtures\MyFooSubClassGraphNode',
+        'foo_object' => MyFooSubClassGraphNode::class,
     ];
 }

--- a/tests/GraphNodes/AbstractGraphNode.php
+++ b/tests/GraphNodes/AbstractGraphNode.php
@@ -25,6 +25,7 @@ namespace Facebook\Tests\GraphNodes;
 
 use Mockery as m;
 use Facebook\GraphNodes\GraphNodeFactory;
+use Facebook\FacebookResponse;
 
 abstract class AbstractGraphNode extends \PHPUnit_Framework_TestCase
 {
@@ -36,7 +37,7 @@ abstract class AbstractGraphNode extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->responseMock = m::mock('\Facebook\FacebookResponse');
+        $this->responseMock = m::mock(FacebookResponse::class);
     }
 
     protected function makeFactoryWithData($data)

--- a/tests/GraphNodes/CollectionTest.php
+++ b/tests/GraphNodes/CollectionTest.php
@@ -126,7 +126,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     {
         $collection = new Collection(['foo' => 'bar', 'faz' => 'baz']);
 
-        $this->assertInstanceOf('IteratorAggregate', $collection);
+        $this->assertInstanceOf(\IteratorAggregate::class, $collection);
 
         $newArray = [];
 

--- a/tests/GraphNodes/GraphAchievementTest.php
+++ b/tests/GraphNodes/GraphAchievementTest.php
@@ -23,6 +23,9 @@
  */
 namespace Facebook\Tests\GraphNodes;
 
+use Facebook\GraphNodes\GraphApplication;
+use Facebook\GraphNodes\GraphUser;
+
 class GraphAchievementTest extends AbstractGraphNode
 {
 
@@ -79,7 +82,7 @@ class GraphAchievementTest extends AbstractGraphNode
 
         $publishTime = $graphNode->getPublishTime();
 
-        $this->assertInstanceOf('DateTime', $publishTime);
+        $this->assertInstanceOf(\DateTime::class, $publishTime);
     }
 
     public function testFromGetsCastAsGraphUser()
@@ -96,7 +99,7 @@ class GraphAchievementTest extends AbstractGraphNode
 
         $from = $graphNode->getFrom();
 
-        $this->assertInstanceOf('\Facebook\GraphNodes\GraphUser', $from);
+        $this->assertInstanceOf(GraphUser::class, $from);
     }
 
     public function testApplicationGetsCastAsGraphApplication()
@@ -112,6 +115,6 @@ class GraphAchievementTest extends AbstractGraphNode
 
         $app = $graphNode->getApplication();
 
-        $this->assertInstanceOf('\Facebook\GraphNodes\GraphApplication', $app);
+        $this->assertInstanceOf(GraphApplication::class, $app);
     }
 }

--- a/tests/GraphNodes/GraphAlbumTest.php
+++ b/tests/GraphNodes/GraphAlbumTest.php
@@ -25,6 +25,9 @@ namespace Facebook\Tests\GraphNodes;
 
 use Mockery as m;
 use Facebook\GraphNodes\GraphNodeFactory;
+use Facebook\GraphNodes\GraphPage;
+use Facebook\GraphNodes\GraphUser;
+use Facebook\FacebookResponse;
 
 class GraphAlbumTest extends \PHPUnit_Framework_TestCase
 {
@@ -36,7 +39,7 @@ class GraphAlbumTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->responseMock = m::mock('\\Facebook\\FacebookResponse');
+        $this->responseMock = m::mock(FacebookResponse::class);
     }
 
     public function testDatesGetCastToDateTime()
@@ -58,8 +61,8 @@ class GraphAlbumTest extends \PHPUnit_Framework_TestCase
         $createdTime = $graphNode->getCreatedTime();
         $updatedTime = $graphNode->getUpdatedTime();
 
-        $this->assertInstanceOf('DateTime', $createdTime);
-        $this->assertInstanceOf('DateTime', $updatedTime);
+        $this->assertInstanceOf(\DateTime::class, $createdTime);
+        $this->assertInstanceOf(\DateTime::class, $updatedTime);
     }
 
     public function testFromGetsCastAsGraphUser()
@@ -81,7 +84,7 @@ class GraphAlbumTest extends \PHPUnit_Framework_TestCase
 
         $from = $graphNode->getFrom();
 
-        $this->assertInstanceOf('\\Facebook\\GraphNodes\\GraphUser', $from);
+        $this->assertInstanceOf(GraphUser::class, $from);
     }
 
     public function testPlacePropertyWillGetCastAsGraphPageObject()
@@ -104,6 +107,6 @@ class GraphAlbumTest extends \PHPUnit_Framework_TestCase
 
         $place = $graphNode->getPlace();
 
-        $this->assertInstanceOf('\\Facebook\\GraphNodes\\GraphPage', $place);
+        $this->assertInstanceOf(GraphPage::class, $place);
     }
 }

--- a/tests/GraphNodes/GraphEdgeTest.php
+++ b/tests/GraphNodes/GraphEdgeTest.php
@@ -90,8 +90,8 @@ class GraphEdgeTest extends \PHPUnit_Framework_TestCase
         $nextPage = $graphEdge->getNextPageRequest();
         $prevPage = $graphEdge->getPreviousPageRequest();
 
-        $this->assertInstanceOf('Facebook\FacebookRequest', $nextPage);
-        $this->assertInstanceOf('Facebook\FacebookRequest', $prevPage);
+        $this->assertInstanceOf(FacebookRequest::class, $nextPage);
+        $this->assertInstanceOf(FacebookRequest::class, $prevPage);
         $this->assertNotSame($this->request, $nextPage);
         $this->assertNotSame($this->request, $prevPage);
         $this->assertEquals('/v1337/998899/photos?access_token=foo_token&after=foo_after_cursor&appsecret_proof=857d5f035a894f16b4180f19966e055cdeab92d4d53017b13dccd6d43b6497af&foo=bar&limit=25&pretty=0', $nextPage->getUrl());

--- a/tests/GraphNodes/GraphEventTest.php
+++ b/tests/GraphNodes/GraphEventTest.php
@@ -26,6 +26,10 @@ namespace Facebook\Tests\GraphNodes;
 use Facebook\FacebookResponse;
 use Mockery as m;
 use Facebook\GraphNodes\GraphNodeFactory;
+use Facebook\GraphNodes\GraphGroup;
+use Facebook\GraphNodes\GraphPicture;
+use Facebook\GraphNodes\GraphPage;
+use Facebook\GraphNodes\GraphCoverPhoto;
 
 class GraphEventTest extends \PHPUnit_Framework_TestCase
 {
@@ -36,7 +40,7 @@ class GraphEventTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->responseMock = m::mock('\Facebook\FacebookResponse');
+        $this->responseMock = m::mock(FacebookResponse::class);
     }
 
     public function testCoverGetsCastAsGraphCoverPhoto()
@@ -53,7 +57,7 @@ class GraphEventTest extends \PHPUnit_Framework_TestCase
         $graphObject = $factory->makeGraphEvent();
 
         $cover = $graphObject->getCover();
-        $this->assertInstanceOf('\Facebook\GraphNodes\GraphCoverPhoto', $cover);
+        $this->assertInstanceOf(GraphCoverPhoto::class, $cover);
     }
 
     public function testPlaceGetsCastAsGraphPage()
@@ -70,7 +74,7 @@ class GraphEventTest extends \PHPUnit_Framework_TestCase
         $graphObject = $factory->makeGraphEvent();
 
         $place = $graphObject->getPlace();
-        $this->assertInstanceOf('\Facebook\GraphNodes\GraphPage', $place);
+        $this->assertInstanceOf(GraphPage::class, $place);
     }
 
     public function testPictureGetsCastAsGraphPicture()
@@ -87,7 +91,7 @@ class GraphEventTest extends \PHPUnit_Framework_TestCase
         $graphObject = $factory->makeGraphEvent();
 
         $picture = $graphObject->getPicture();
-        $this->assertInstanceOf('\Facebook\GraphNodes\GraphPicture', $picture);
+        $this->assertInstanceOf(GraphPicture::class, $picture);
     }
 
     public function testParentGroupGetsCastAsGraphGroup()
@@ -104,6 +108,6 @@ class GraphEventTest extends \PHPUnit_Framework_TestCase
         $graphObject = $factory->makeGraphEvent();
 
         $parentGroup = $graphObject->getParentGroup();
-        $this->assertInstanceOf('\Facebook\GraphNodes\GraphGroup', $parentGroup);
+        $this->assertInstanceOf(GraphGroup::class, $parentGroup);
     }
 }

--- a/tests/GraphNodes/GraphGroupTest.php
+++ b/tests/GraphNodes/GraphGroupTest.php
@@ -26,6 +26,8 @@ namespace Facebook\Tests\GraphNodes;
 use Facebook\FacebookResponse;
 use Mockery as m;
 use Facebook\GraphNodes\GraphNodeFactory;
+use Facebook\GraphNodes\GraphLocation;
+use Facebook\GraphNodes\GraphCoverPhoto;
 
 class GraphGroupTest extends \PHPUnit_Framework_TestCase
 {
@@ -36,7 +38,7 @@ class GraphGroupTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->responseMock = m::mock('\Facebook\FacebookResponse');
+        $this->responseMock = m::mock(FacebookResponse::class);
     }
 
     public function testCoverGetsCastAsGraphCoverPhoto()
@@ -53,7 +55,7 @@ class GraphGroupTest extends \PHPUnit_Framework_TestCase
         $graphNode = $factory->makeGraphGroup();
 
         $cover = $graphNode->getCover();
-        $this->assertInstanceOf('\Facebook\GraphNodes\GraphCoverPhoto', $cover);
+        $this->assertInstanceOf(GraphCoverPhoto::class, $cover);
     }
 
     public function testVenueGetsCastAsGraphLocation()
@@ -70,6 +72,6 @@ class GraphGroupTest extends \PHPUnit_Framework_TestCase
         $graphNode = $factory->makeGraphGroup();
 
         $venue = $graphNode->getVenue();
-        $this->assertInstanceOf('\Facebook\GraphNodes\GraphLocation', $venue);
+        $this->assertInstanceOf(GraphLocation::class, $venue);
     }
 }

--- a/tests/GraphNodes/GraphNodeFactoryTest.php
+++ b/tests/GraphNodes/GraphNodeFactoryTest.php
@@ -27,6 +27,11 @@ use Facebook\FacebookApp;
 use Facebook\FacebookRequest;
 use Facebook\FacebookResponse;
 use Facebook\GraphNodes\GraphNodeFactory;
+use Facebook\GraphNodes\GraphNode;
+use Facebook\GraphNodes\GraphEdge;
+use Facebook\Tests\Fixtures\MyFooGraphNode;
+use Facebook\Tests\Fixtures\MyFooSubClassGraphNode;
+use Facebook\GraphNodes\GraphAlbum;
 
 class GraphNodeFactoryTest extends \PHPUnit_Framework_TestCase
 {
@@ -112,9 +117,9 @@ class GraphNodeFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testValidSubClassesWillNotThrow()
     {
-        GraphNodeFactory::validateSubclass('\Facebook\GraphNodes\GraphNode');
-        GraphNodeFactory::validateSubclass('\Facebook\GraphNodes\GraphAlbum');
-        GraphNodeFactory::validateSubclass('\Facebook\Tests\Fixtures\MyFooGraphNode');
+        GraphNodeFactory::validateSubclass(GraphNode::class);
+        GraphNodeFactory::validateSubclass(GraphAlbum::class);
+        GraphNodeFactory::validateSubclass(MyFooGraphNode::class);
     }
 
     public function testCastingAsASubClassObjectWillInstantiateTheSubClass()
@@ -123,9 +128,9 @@ class GraphNodeFactoryTest extends \PHPUnit_Framework_TestCase
         $res = new FacebookResponse($this->request, $data);
 
         $factory = new GraphNodeFactory($res);
-        $mySubClassObject = $factory->makeGraphNode('\Facebook\Tests\Fixtures\MyFooGraphNode');
+        $mySubClassObject = $factory->makeGraphNode(MyFooGraphNode::class);
 
-        $this->assertInstanceOf('\Facebook\Tests\Fixtures\MyFooGraphNode', $mySubClassObject);
+        $this->assertInstanceOf(MyFooGraphNode::class, $mySubClassObject);
     }
 
     public function testASubClassMappingWillAutomaticallyInstantiateSubClass()
@@ -134,11 +139,11 @@ class GraphNodeFactoryTest extends \PHPUnit_Framework_TestCase
         $res = new FacebookResponse($this->request, $data);
 
         $factory = new GraphNodeFactory($res);
-        $mySubClassObject = $factory->makeGraphNode('\Facebook\Tests\Fixtures\MyFooGraphNode');
+        $mySubClassObject = $factory->makeGraphNode(MyFooGraphNode::class);
         $fooObject = $mySubClassObject->getField('foo_object');
 
-        $this->assertInstanceOf('\Facebook\Tests\Fixtures\MyFooGraphNode', $mySubClassObject);
-        $this->assertInstanceOf('\Facebook\Tests\Fixtures\MyFooSubClassGraphNode', $fooObject);
+        $this->assertInstanceOf(MyFooGraphNode::class, $mySubClassObject);
+        $this->assertInstanceOf(MyFooSubClassGraphNode::class, $fooObject);
     }
 
     public function testAnUnknownGraphNodeWillBeCastAsAGenericGraphNode()
@@ -155,12 +160,12 @@ class GraphNodeFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory = new GraphNodeFactory($res);
 
-        $mySubClassObject = $factory->makeGraphNode('\Facebook\Tests\Fixtures\MyFooGraphNode');
+        $mySubClassObject = $factory->makeGraphNode(MyFooGraphNode::class);
         $unknownObject = $mySubClassObject->getField('unknown_object');
 
-        $this->assertInstanceOf('\Facebook\Tests\Fixtures\MyFooGraphNode', $mySubClassObject);
-        $this->assertInstanceOf('\Facebook\GraphNodes\GraphNode', $unknownObject);
-        $this->assertNotInstanceOf('\Facebook\Tests\Fixtures\MyFooGraphNode', $unknownObject);
+        $this->assertInstanceOf(MyFooGraphNode::class, $mySubClassObject);
+        $this->assertInstanceOf(GraphNode::class, $unknownObject);
+        $this->assertNotInstanceOf(MyFooGraphNode::class, $unknownObject);
     }
 
     public function testAListFromGraphWillBeCastAsAGraphEdge()
@@ -189,7 +194,7 @@ class GraphNodeFactoryTest extends \PHPUnit_Framework_TestCase
         $graphEdge = $factory->makeGraphEdge();
         $graphData = $graphEdge->asArray();
 
-        $this->assertInstanceOf('\Facebook\GraphNodes\GraphEdge', $graphEdge);
+        $this->assertInstanceOf(GraphEdge::class, $graphEdge);
         $this->assertEquals([
             'id' => '123',
             'name' => 'Foo McBar',
@@ -215,7 +220,7 @@ class GraphNodeFactoryTest extends \PHPUnit_Framework_TestCase
         $graphNode = $factory->makeGraphNode();
         $graphData = $graphNode->asArray();
 
-        $this->assertInstanceOf('\Facebook\GraphNodes\GraphNode', $graphNode);
+        $this->assertInstanceOf(GraphNode::class, $graphNode);
         $this->assertEquals([
             'id' => '123',
             'name' => 'Foo McBar',
@@ -239,7 +244,7 @@ class GraphNodeFactoryTest extends \PHPUnit_Framework_TestCase
         $graphNode = $factory->makeGraphNode();
         $graphData = $graphNode->asArray();
 
-        $this->assertInstanceOf('\Facebook\GraphNodes\GraphNode', $graphNode);
+        $this->assertInstanceOf(GraphNode::class, $graphNode);
         $this->assertEquals([
             'id' => '123',
             'name' => 'Foo McBar',
@@ -333,24 +338,24 @@ class GraphNodeFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory = new GraphNodeFactory($res);
         $graphNode = $factory->makeGraphEdge();
-        $this->assertInstanceOf('\Facebook\GraphNodes\GraphEdge', $graphNode);
+        $this->assertInstanceOf(GraphEdge::class, $graphNode);
 
         // Story
         $storyObject = $graphNode[0];
-        $this->assertInstanceOf('\Facebook\GraphNodes\GraphNode', $storyObject['from']);
-        $this->assertInstanceOf('\Facebook\GraphNodes\GraphEdge', $storyObject['likes']);
-        $this->assertInstanceOf('\Facebook\GraphNodes\GraphEdge', $storyObject['comments']);
+        $this->assertInstanceOf(GraphNode::class, $storyObject['from']);
+        $this->assertInstanceOf(GraphEdge::class, $storyObject['likes']);
+        $this->assertInstanceOf(GraphEdge::class, $storyObject['comments']);
 
         // Story Comments
         $storyComments = $storyObject['comments'];
         $firstStoryComment = $storyComments[0];
-        $this->assertInstanceOf('\Facebook\GraphNodes\GraphNode', $firstStoryComment['from']);
+        $this->assertInstanceOf(GraphNode::class, $firstStoryComment['from']);
 
         // Message
         $messageObject = $graphNode[1];
-        $this->assertInstanceOf('\Facebook\GraphNodes\GraphEdge', $messageObject['to']);
+        $this->assertInstanceOf(GraphEdge::class, $messageObject['to']);
         $toUsers = $messageObject['to'];
-        $this->assertInstanceOf('\Facebook\GraphNodes\GraphNode', $toUsers[0]);
+        $this->assertInstanceOf(GraphNode::class, $toUsers[0]);
     }
 
     public function testAGraphEdgeWillGenerateTheProperParentGraphEdges()

--- a/tests/GraphNodes/GraphNodeTest.php
+++ b/tests/GraphNodes/GraphNodeTest.php
@@ -76,7 +76,7 @@ class GraphNodeTest extends \PHPUnit_Framework_TestCase
         $prettyDate = $dateTime->format(\DateTime::RFC1036);
         $timeStamp = $dateTime->getTimestamp();
 
-        $this->assertInstanceOf('DateTime', $dateTime);
+        $this->assertInstanceOf(\DateTime::class, $dateTime);
         $this->assertEquals('Wed, 16 Jul 14 23:43:40 +0200', $prettyDate);
         $this->assertEquals(1405547020, $timeStamp);
     }
@@ -89,7 +89,7 @@ class GraphNodeTest extends \PHPUnit_Framework_TestCase
         $prettyDate = $dateTime->format(\DateTime::RFC1036);
         $timeStamp = $dateTime->getTimestamp();
 
-        $this->assertInstanceOf('DateTime', $dateTime);
+        $this->assertInstanceOf(\DateTime::class, $dateTime);
         $this->assertEquals('Tue, 15 Jul 14 03:44:53 +0000', $prettyDate);
         $this->assertEquals(1405395893, $timeStamp);
     }
@@ -121,7 +121,7 @@ class GraphNodeTest extends \PHPUnit_Framework_TestCase
 
         $collectionAsArray = $collection->asArray();
 
-        $this->assertInstanceOf('DateTime', $collectionAsArray['date']);
+        $this->assertInstanceOf(\DateTime::class, $collectionAsArray['date']);
     }
 
     public function testReturningACollectionAsJasonWillSafelyRepresentDateTimes()

--- a/tests/GraphNodes/GraphObjectFactoryTest.php
+++ b/tests/GraphNodes/GraphObjectFactoryTest.php
@@ -27,6 +27,8 @@ use Facebook\GraphNodes\GraphObjectFactory;
 use Facebook\FacebookApp;
 use Facebook\FacebookRequest;
 use Facebook\FacebookResponse;
+use Facebook\GraphNodes\GraphList;
+use Facebook\GraphNodes\GraphObject;
 
 /**
  * @todo v6: Remove this test
@@ -65,7 +67,7 @@ class GraphObjectFactoryTest extends \PHPUnit_Framework_TestCase
         $graphObject = $factory->makeGraphObject();
         $graphData = $graphObject->asArray();
 
-        $this->assertInstanceOf('\Facebook\GraphNodes\GraphObject', $graphObject);
+        $this->assertInstanceOf(GraphObject::class, $graphObject);
         $this->assertEquals([
             'id' => '123',
             'name' => 'Foo McBar',
@@ -99,7 +101,7 @@ class GraphObjectFactoryTest extends \PHPUnit_Framework_TestCase
         $graphList = $factory->makeGraphList();
         $graphData = $graphList->asArray();
 
-        $this->assertInstanceOf('\Facebook\GraphNodes\GraphList', $graphList);
+        $this->assertInstanceOf(GraphList::class, $graphList);
         $this->assertEquals([
           'id' => '123',
           'name' => 'Foo McBar',

--- a/tests/GraphNodes/GraphPageTest.php
+++ b/tests/GraphNodes/GraphPageTest.php
@@ -25,6 +25,9 @@ namespace Facebook\Tests\GraphNodes;
 
 use Mockery as m;
 use Facebook\GraphNodes\GraphNodeFactory;
+use Facebook\GraphNodes\GraphLocation;
+use Facebook\GraphNodes\GraphPage;
+use Facebook\FacebookResponse;
 
 class GraphPageTest extends \PHPUnit_Framework_TestCase
 {
@@ -35,7 +38,7 @@ class GraphPageTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->responseMock = m::mock('\\Facebook\\FacebookResponse');
+        $this->responseMock = m::mock(FacebookResponse::class);
     }
 
     public function testPagePropertiesReturnGraphPageObjects()
@@ -63,8 +66,8 @@ class GraphPageTest extends \PHPUnit_Framework_TestCase
         $bestPage = $graphNode->getBestPage();
         $globalBrandParentPage = $graphNode->getGlobalBrandParentPage();
 
-        $this->assertInstanceOf('\\Facebook\\GraphNodes\\GraphPage', $bestPage);
-        $this->assertInstanceOf('\\Facebook\\GraphNodes\\GraphPage', $globalBrandParentPage);
+        $this->assertInstanceOf(GraphPage::class, $bestPage);
+        $this->assertInstanceOf(GraphPage::class, $globalBrandParentPage);
     }
 
     public function testLocationPropertyWillGetCastAsGraphLocationObject()
@@ -90,6 +93,6 @@ class GraphPageTest extends \PHPUnit_Framework_TestCase
 
         $location = $graphNode->getLocation();
 
-        $this->assertInstanceOf('\\Facebook\\GraphNodes\\GraphLocation', $location);
+        $this->assertInstanceOf(GraphLocation::class, $location);
     }
 }

--- a/tests/GraphNodes/GraphSessionInfoTest.php
+++ b/tests/GraphNodes/GraphSessionInfoTest.php
@@ -25,6 +25,7 @@ namespace Facebook\Tests\GraphNodes;
 
 use Mockery as m;
 use Facebook\GraphNodes\GraphNodeFactory;
+use Facebook\FacebookResponse;
 
 class GraphSessionInfoTest extends \PHPUnit_Framework_TestCase
 {
@@ -35,7 +36,7 @@ class GraphSessionInfoTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->responseMock = m::mock('\\Facebook\\FacebookResponse');
+        $this->responseMock = m::mock(FacebookResponse::class);
     }
 
     public function testDatesGetCastToDateTime()
@@ -56,7 +57,7 @@ class GraphSessionInfoTest extends \PHPUnit_Framework_TestCase
         $expires = $graphNode->getExpiresAt();
         $issuedAt = $graphNode->getIssuedAt();
 
-        $this->assertInstanceOf('DateTime', $expires);
-        $this->assertInstanceOf('DateTime', $issuedAt);
+        $this->assertInstanceOf(\DateTime::class, $expires);
+        $this->assertInstanceOf(\DateTime::class, $issuedAt);
     }
 }

--- a/tests/GraphNodes/GraphUserTest.php
+++ b/tests/GraphNodes/GraphUserTest.php
@@ -26,6 +26,10 @@ namespace Facebook\Tests\GraphNodes;
 use Facebook\FacebookResponse;
 use Mockery as m;
 use Facebook\GraphNodes\GraphNodeFactory;
+use Facebook\GraphNodes\GraphPicture;
+use Facebook\GraphNodes\GraphUser;
+use Facebook\GraphNodes\GraphPage;
+use Facebook\GraphNodes\Birthday;
 
 class GraphUserTest extends \PHPUnit_Framework_TestCase
 {
@@ -36,7 +40,7 @@ class GraphUserTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->responseMock = m::mock('\\Facebook\\FacebookResponse');
+        $this->responseMock = m::mock(FacebookResponse::class);
     }
 
     public function testDatesGetCastToDateTime()
@@ -54,7 +58,7 @@ class GraphUserTest extends \PHPUnit_Framework_TestCase
 
         $updatedTime = $graphNode->getField('updated_time');
 
-        $this->assertInstanceOf('DateTime', $updatedTime);
+        $this->assertInstanceOf(\DateTime::class, $updatedTime);
     }
 
     public function testBirthdaysGetCastToBirthday()
@@ -73,9 +77,9 @@ class GraphUserTest extends \PHPUnit_Framework_TestCase
         $birthday = $graphNode->getBirthday();
 
         // Test to ensure BC
-        $this->assertInstanceOf('DateTime', $birthday);
+        $this->assertInstanceOf(\DateTime::class, $birthday);
 
-        $this->assertInstanceOf('\\Facebook\\GraphNodes\\Birthday', $birthday);
+        $this->assertInstanceOf(Birthday::class, $birthday);
         $this->assertTrue($birthday->hasDate());
         $this->assertTrue($birthday->hasYear());
         $this->assertEquals('1984/01/01', $birthday->format('Y/m/d'));
@@ -146,8 +150,8 @@ class GraphUserTest extends \PHPUnit_Framework_TestCase
         $hometown = $graphNode->getHometown();
         $location = $graphNode->getLocation();
 
-        $this->assertInstanceOf('\\Facebook\\GraphNodes\\GraphPage', $hometown);
-        $this->assertInstanceOf('\\Facebook\\GraphNodes\\GraphPage', $location);
+        $this->assertInstanceOf(GraphPage::class, $hometown);
+        $this->assertInstanceOf(GraphPage::class, $location);
     }
 
     public function testUserPropertiesWillGetCastAsGraphUserObjects()
@@ -170,7 +174,7 @@ class GraphUserTest extends \PHPUnit_Framework_TestCase
 
         $significantOther = $graphNode->getSignificantOther();
 
-        $this->assertInstanceOf('\\Facebook\\GraphNodes\\GraphUser', $significantOther);
+        $this->assertInstanceOf(GraphUser::class, $significantOther);
     }
 
     public function testPicturePropertiesWillGetCastAsGraphPictureObjects()
@@ -195,7 +199,7 @@ class GraphUserTest extends \PHPUnit_Framework_TestCase
 
         $Picture = $graphNode->getPicture();
 
-        $this->assertInstanceOf('\\Facebook\\GraphNodes\\GraphPicture', $Picture);
+        $this->assertInstanceOf(GraphPicture::class, $Picture);
         $this->assertTrue($Picture->isSilhouette());
         $this->assertEquals(200, $Picture->getWidth());
         $this->assertEquals(200, $Picture->getHeight());

--- a/tests/Helpers/FacebookSignedRequestFromInputHelperTest.php
+++ b/tests/Helpers/FacebookSignedRequestFromInputHelperTest.php
@@ -27,6 +27,7 @@ use Facebook\FacebookApp;
 use Facebook\Tests\FacebookTest;
 use Facebook\Tests\Fixtures\FooSignedRequestHelper;
 use Facebook\Tests\Fixtures\FooSignedRequestHelperFacebookClient;
+use Facebook\Authentication\AccessToken;
 
 class FacebookSignedRequestFromInputHelperTest extends \PHPUnit_Framework_TestCase
 {
@@ -76,7 +77,7 @@ class FacebookSignedRequestFromInputHelperTest extends \PHPUnit_Framework_TestCa
         $this->helper->instantiateSignedRequest($this->rawSignedRequestAuthorizedWithAccessToken);
         $accessToken = $this->helper->getAccessToken();
 
-        $this->assertInstanceOf('Facebook\Authentication\AccessToken', $accessToken);
+        $this->assertInstanceOf(AccessToken::class, $accessToken);
         $this->assertEquals('foo_token', $accessToken->getValue());
     }
 
@@ -85,7 +86,7 @@ class FacebookSignedRequestFromInputHelperTest extends \PHPUnit_Framework_TestCa
         $this->helper->instantiateSignedRequest($this->rawSignedRequestAuthorizedWithCode);
         $accessToken = $this->helper->getAccessToken();
 
-        $this->assertInstanceOf('Facebook\Authentication\AccessToken', $accessToken);
+        $this->assertInstanceOf(AccessToken::class, $accessToken);
         $this->assertEquals('foo_access_token_from:foo_code', $accessToken->getValue());
     }
 }

--- a/tests/HttpClients/FacebookCurlHttpClientTest.php
+++ b/tests/HttpClients/FacebookCurlHttpClientTest.php
@@ -25,6 +25,8 @@ namespace Facebook\Tests\HttpClients;
 
 use Mockery as m;
 use Facebook\HttpClients\FacebookCurlHttpClient;
+use Facebook\HttpClients\FacebookCurl;
+use Facebook\Http\GraphRawResponse;
 
 class FacebookCurlHttpClientTest extends AbstractTestHttpClient
 {
@@ -46,7 +48,7 @@ class FacebookCurlHttpClientTest extends AbstractTestHttpClient
         if (!extension_loaded('curl')) {
             $this->markTestSkipped('cURL must be installed to test cURL client handler.');
         }
-        $this->curlMock = m::mock('Facebook\HttpClients\FacebookCurl');
+        $this->curlMock = m::mock(FacebookCurl::class);
         $this->curlClient = new FacebookCurlHttpClient($this->curlMock);
     }
 
@@ -246,7 +248,7 @@ class FacebookCurlHttpClientTest extends AbstractTestHttpClient
 
         $response = $this->curlClient->send('http://foo.com/', 'GET', '', [], 60);
 
-        $this->assertInstanceOf('Facebook\Http\GraphRawResponse', $response);
+        $this->assertInstanceOf(GraphRawResponse::class, $response);
         $this->assertEquals($this->fakeRawBody, $response->getBody());
         $this->assertEquals($this->fakeHeadersAsArray, $response->getHeaders());
         $this->assertEquals(200, $response->getHttpResponseCode());

--- a/tests/HttpClients/FacebookGuzzleHttpClientTest.php
+++ b/tests/HttpClients/FacebookGuzzleHttpClientTest.php
@@ -29,6 +29,8 @@ use GuzzleHttp\Message\Request;
 use GuzzleHttp\Message\Response;
 use GuzzleHttp\Stream\Stream;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Client;
+use Facebook\Http\GraphRawResponse;
 
 class FacebookGuzzleHttpClientTest extends AbstractTestHttpClient
 {
@@ -44,7 +46,7 @@ class FacebookGuzzleHttpClientTest extends AbstractTestHttpClient
 
     protected function setUp()
     {
-        $this->guzzleMock = m::mock('GuzzleHttp\Client');
+        $this->guzzleMock = m::mock(Client::class);
         $this->guzzleClient = new FacebookGuzzleHttpClient($this->guzzleMock);
     }
 
@@ -91,7 +93,7 @@ class FacebookGuzzleHttpClientTest extends AbstractTestHttpClient
 
         $response = $this->guzzleClient->send('http://foo.com/', 'GET', 'foo_body', ['X-foo' => 'bar'], 123);
 
-        $this->assertInstanceOf('Facebook\Http\GraphRawResponse', $response);
+        $this->assertInstanceOf(GraphRawResponse::class, $response);
         $this->assertEquals($this->fakeRawBody, $response->getBody());
         $this->assertEquals($this->fakeHeadersAsArray, $response->getHeaders());
         $this->assertEquals(200, $response->getHttpResponseCode());

--- a/tests/HttpClients/FacebookStreamHttpClientTest.php
+++ b/tests/HttpClients/FacebookStreamHttpClientTest.php
@@ -25,6 +25,8 @@ namespace Facebook\Tests\HttpClients;
 
 use Mockery as m;
 use Facebook\HttpClients\FacebookStreamHttpClient;
+use Facebook\HttpClients\FacebookStream;
+use Facebook\Http\GraphRawResponse;
 
 class FacebookStreamHttpClientTest extends AbstractTestHttpClient
 {
@@ -40,7 +42,7 @@ class FacebookStreamHttpClientTest extends AbstractTestHttpClient
 
     protected function setUp()
     {
-        $this->streamMock = m::mock('Facebook\HttpClients\FacebookStream');
+        $this->streamMock = m::mock(FacebookStream::class);
         $this->streamClient = new FacebookStreamHttpClient($this->streamMock);
     }
 
@@ -104,7 +106,7 @@ class FacebookStreamHttpClientTest extends AbstractTestHttpClient
 
         $response = $this->streamClient->send('http://foo.com/', 'GET', 'foo_body', ['X-foo' => 'bar'], 123);
 
-        $this->assertInstanceOf('Facebook\Http\GraphRawResponse', $response);
+        $this->assertInstanceOf(GraphRawResponse::class, $response);
         $this->assertEquals($this->fakeRawBody, $response->getBody());
         $this->assertEquals($this->fakeHeadersAsArray, $response->getHeaders());
         $this->assertEquals(200, $response->getHttpResponseCode());

--- a/tests/HttpClients/HttpClientsFactoryTest.php
+++ b/tests/HttpClients/HttpClientsFactoryTest.php
@@ -29,11 +29,12 @@ use Facebook\HttpClients\FacebookStreamHttpClient;
 use Facebook\HttpClients\HttpClientsFactory;
 use GuzzleHttp\Client;
 use PHPUnit_Framework_TestCase;
+use Facebook\HttpClients\FacebookHttpClientInterface;
 
 class HttpClientsFactoryTest extends PHPUnit_Framework_TestCase
 {
     const COMMON_NAMESPACE = 'Facebook\HttpClients\\';
-    const COMMON_INTERFACE = 'Facebook\HttpClients\FacebookHttpClientInterface';
+    const COMMON_INTERFACE = FacebookHttpClientInterface::class;
 
     /**
      * @param mixed  $handler

--- a/tests/PersistentData/PersistentDataFactoryTest.php
+++ b/tests/PersistentData/PersistentDataFactoryTest.php
@@ -27,11 +27,12 @@ use Facebook\PersistentData\FacebookMemoryPersistentDataHandler;
 use Facebook\PersistentData\FacebookSessionPersistentDataHandler;
 use Facebook\PersistentData\PersistentDataFactory;
 use PHPUnit_Framework_TestCase;
+use Facebook\PersistentData\PersistentDataInterface;
 
 class PersistentDataFactoryTest extends PHPUnit_Framework_TestCase
 {
     const COMMON_NAMESPACE = 'Facebook\PersistentData\\';
-    const COMMON_INTERFACE = 'Facebook\PersistentData\PersistentDataInterface';
+    const COMMON_INTERFACE = PersistentDataInterface::class;
 
     /**
      * @param mixed  $handler


### PR DESCRIPTION
This PR

* [x] makes use of the `class` keyword instead of specifying class names by string literals
