### PR TITLE
Enhancement: Require latest version of phpunit/phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "paragonie/random_compat": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "^5.7.5",
         "mockery/mockery": "~0.8",
         "guzzlehttp/guzzle": "~5.0"
     },


### PR DESCRIPTION
This PR

* [x] requires the latest version of `phpunit/phpunit`

Follows 7009ef8bc0415c6da9df1c13ede668b4a6e7b970.

💁‍♂️ Because why would we still use an older version if we can use a newer one? For reference, also see https://github.com/sebastianbergmann/phpunit/compare/4.8.30...5.7.5.