### PR TITLE
Fix: Apply PSR-2 to credentials template

### DIFF
--- a/tests/FacebookTestCredentials.php.dist
+++ b/tests/FacebookTestCredentials.php.dist
@@ -23,14 +23,13 @@
  */
 namespace Facebook\Tests;
 
-class FacebookTestCredentials {
-
-  /**
-   * These must be filled out with valid Facebook app details for the tests to
-   * run.
-   */
-  public static $appId = '';
-  public static $appSecret = '';
-
+class FacebookTestCredentials
+{
+    /**
+     * These must be filled out with valid Facebook app details for the tests to
+     * run.
+     */
+    public static $appId = '';
+    public static $appSecret = '';
 }
 


### PR DESCRIPTION
This PR 

* [x] applies PSR-2 to the test credentials template file