### PR TITLE
Fix: Use double pipe for specifying alternate PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^5.6|^7.0",
+        "php": "^5.6 || ^7.0",
         "paragonie/random_compat": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR

* [x] uses `||` when specifying platform requirements

💁‍♂️ While `|` is also supported, the documentation suggests to use `||`. For reference, see https://getcomposer.org/doc/articles/versions.md#range.