### PR TITLE
Add PHP 7.1 to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 sudo: false

--- a/tests/PseudoRandomString/McryptPseudoRandomStringGeneratorTest.php
+++ b/tests/PseudoRandomString/McryptPseudoRandomStringGeneratorTest.php
@@ -29,6 +29,10 @@ class McryptPseudoRandomStringGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     public function testCanGenerateRandomStringOfArbitraryLength()
     {
+        if (version_compare(PHP_VERSION, '7.1', '>=')) {
+            $this->markTestSkipped('Skipping test mcrypt is deprecated from 7.1');
+        }
+
         if (!function_exists('mcrypt_create_iv')) {
             $this->markTestSkipped(
                 'Mcrypt must be installed to test mcrypt_create_iv().'


### PR DESCRIPTION
I have added 7.1 to Travis build and marked the mcrypt random string test as skipped for >=7.1 because it will never be returned anyway (check https://github.com/facebook/php-graph-sdk/blob/5.4/src/Facebook/PseudoRandomString/PseudoRandomStringGeneratorFactory.php#L80).