### PR TITLE
Generate Better OpCode

### DIFF
--- a/src/Facebook/Authentication/AccessToken.php
+++ b/src/Facebook/Authentication/AccessToken.php
@@ -67,7 +67,7 @@ class AccessToken
      */
     public function getAppSecretProof($appSecret)
     {
-        return hash_hmac('sha256', $this->value, $appSecret);
+        return \hash_hmac('sha256', $this->value, $appSecret);
     }
 
     /**
@@ -87,7 +87,7 @@ class AccessToken
      */
     public function isAppAccessToken()
     {
-        return strpos($this->value, '|') !== false;
+        return \strpos($this->value, '|') !== false;
     }
 
     /**
@@ -98,7 +98,7 @@ class AccessToken
     public function isLongLived()
     {
         if ($this->expiresAt) {
-            return $this->expiresAt->getTimestamp() > time() + (60 * 60 * 2);
+            return $this->expiresAt->getTimestamp() > \time() + (60 * 60 * 2);
         }
 
         if ($this->isAppAccessToken()) {
@@ -116,7 +116,7 @@ class AccessToken
     public function isExpired()
     {
         if ($this->getExpiresAt() instanceof \DateTime) {
-            return $this->getExpiresAt()->getTimestamp() < time();
+            return $this->getExpiresAt()->getTimestamp() < \time();
         }
 
         if ($this->isAppAccessToken()) {

--- a/src/Facebook/Authentication/AccessTokenMetadata.php
+++ b/src/Facebook/Authentication/AccessTokenMetadata.php
@@ -356,7 +356,7 @@ class AccessTokenMetadata
             return;
         }
 
-        if ($this->getExpiresAt()->getTimestamp() < time()) {
+        if ($this->getExpiresAt()->getTimestamp() < \time()) {
             throw new FacebookSDKException('Inspection of access token metadata shows that the access token has expired.', 401);
         }
     }

--- a/src/Facebook/Authentication/OAuth2Client.php
+++ b/src/Facebook/Authentication/OAuth2Client.php
@@ -140,10 +140,10 @@ class OAuth2Client
             'response_type' => 'code',
             'sdk' => 'php-sdk-' . Facebook::VERSION,
             'redirect_uri' => $redirectUrl,
-            'scope' => implode(',', $scope)
+            'scope' => \implode(',', $scope)
         ];
 
-        return static::BASE_AUTHORIZATION_URL . '/' . $this->graphVersion . '/dialog/oauth?' . http_build_query($params, null, $separator);
+        return static::BASE_AUTHORIZATION_URL . '/' . $this->graphVersion . '/dialog/oauth?' . \http_build_query($params, null, $separator);
     }
 
     /**
@@ -236,12 +236,12 @@ class OAuth2Client
         if (isset($data['expires'])) {
             // For exchanging a short lived token with a long lived token.
             // The expiration time in seconds will be returned as "expires".
-            $expiresAt = time() + $data['expires'];
+            $expiresAt = \time() + $data['expires'];
         } elseif (isset($data['expires_in'])) {
             // For exchanging a code for a short lived access token.
             // The expiration time in seconds will be returned as "expires_in".
             // See: https://developers.facebook.com/docs/facebook-login/access-tokens#long-via-code
-            $expiresAt = time() + $data['expires_in'];
+            $expiresAt = \time() + $data['expires_in'];
         }
 
         return new AccessToken($data['access_token'], $expiresAt);

--- a/src/Facebook/Facebook.php
+++ b/src/Facebook/Facebook.php
@@ -124,9 +124,9 @@ class Facebook
      */
     public function __construct(array $config = [])
     {
-        $config = array_merge([
-            'app_id' => getenv(static::APP_ID_ENV_NAME),
-            'app_secret' => getenv(static::APP_SECRET_ENV_NAME),
+        $config = \array_merge([
+            'app_id' => \getenv(static::APP_ID_ENV_NAME),
+            'app_secret' => \getenv(static::APP_SECRET_ENV_NAME),
             'default_graph_version' => static::DEFAULT_GRAPH_VERSION,
             'enable_beta_mode' => false,
             'http_client_handler' => null,
@@ -248,7 +248,7 @@ class Facebook
      */
     public function setDefaultAccessToken($accessToken)
     {
-        if (is_string($accessToken)) {
+        if (\is_string($accessToken)) {
             $this->defaultAccessToken = new AccessToken($accessToken);
 
             return;
@@ -443,7 +443,7 @@ class Facebook
         $subClassName = $graphEdge->getSubClassName();
         $graphEdge = $this->lastResponse->getGraphEdge($subClassName, false);
 
-        return count($graphEdge) > 0 ? $graphEdge : null;
+        return \count($graphEdge) > 0 ? $graphEdge : null;
     }
 
     /**

--- a/src/Facebook/FacebookApp.php
+++ b/src/Facebook/FacebookApp.php
@@ -46,9 +46,9 @@ class FacebookApp implements \Serializable
      */
     public function __construct($id, $secret)
     {
-        if (!is_string($id)
+        if (!\is_string($id)
           // Keeping this for BC. Integers greater than PHP_INT_MAX will make is_int() return false
-          && !is_int($id)) {
+          && !\is_int($id)) {
             throw new FacebookSDKException('The "app_id" must be formatted as a string since many app ID\'s are greater than PHP_INT_MAX on some systems.');
         }
         // We cast as a string in case a valid int was set on a 64-bit system and this is unserialised on a 32-bit system
@@ -93,7 +93,7 @@ class FacebookApp implements \Serializable
      */
     public function serialize()
     {
-        return implode('|', [$this->id, $this->secret]);
+        return \implode('|', [$this->id, $this->secret]);
     }
 
     /**
@@ -103,7 +103,7 @@ class FacebookApp implements \Serializable
      */
     public function unserialize($serialized)
     {
-        list($id, $secret) = explode('|', $serialized);
+        list($id, $secret) = \explode('|', $serialized);
 
         $this->__construct($id, $secret);
     }

--- a/src/Facebook/FacebookBatchRequest.php
+++ b/src/Facebook/FacebookBatchRequest.php
@@ -74,7 +74,7 @@ class FacebookBatchRequest extends FacebookRequest implements IteratorAggregate,
      */
     public function add($request, $options = null)
     {
-        if (is_array($request)) {
+        if (\is_array($request)) {
             foreach ($request as $key => $req) {
                 $this->add($req, $key);
             }
@@ -88,7 +88,7 @@ class FacebookBatchRequest extends FacebookRequest implements IteratorAggregate,
 
         if (null === $options) {
             $options = [];
-        } elseif (!is_array($options)) {
+        } elseif (!\is_array($options)) {
             $options = ['name' => $options];
         }
 
@@ -165,7 +165,7 @@ class FacebookBatchRequest extends FacebookRequest implements IteratorAggregate,
         $request->resetFiles();
 
         // @TODO Does Graph support multiple uploads on one endpoint?
-        return implode(',', $fileNames);
+        return \implode(',', $fileNames);
     }
 
     /**
@@ -212,7 +212,7 @@ class FacebookBatchRequest extends FacebookRequest implements IteratorAggregate,
             $requests[] = $this->requestEntityToBatchArray($request['request'], $options, $request['attached_files']);
         }
 
-        return json_encode($requests);
+        return \json_encode($requests);
     }
 
     /**
@@ -222,7 +222,7 @@ class FacebookBatchRequest extends FacebookRequest implements IteratorAggregate,
      */
     public function validateBatchRequestCount()
     {
-        $batchCount = count($this->requests);
+        $batchCount = \count($this->requests);
         if ($batchCount === 0) {
             throw new FacebookSDKException('There are no batch requests to send.');
         } elseif ($batchCount > 50) {
@@ -246,7 +246,7 @@ class FacebookBatchRequest extends FacebookRequest implements IteratorAggregate,
 
         if (null === $options) {
             $options = [];
-        } elseif (!is_array($options)) {
+        } elseif (!\is_array($options)) {
             $options = ['name' => $options];
         }
 

--- a/src/Facebook/FacebookClient.php
+++ b/src/Facebook/FacebookClient.php
@@ -124,7 +124,7 @@ class FacebookClient
      */
     public function detectHttpClientHandler()
     {
-        return extension_loaded('curl') ? new FacebookCurlHttpClient() : new FacebookStreamHttpClient();
+        return \extension_loaded('curl') ? new FacebookCurlHttpClient() : new FacebookStreamHttpClient();
     }
 
     /**
@@ -197,7 +197,7 @@ class FacebookClient
      */
     public function sendRequest(FacebookRequest $request)
     {
-        if (get_class($request) === 'Facebook\FacebookRequest') {
+        if (\get_class($request) === 'Facebook\FacebookRequest') {
             $request->validateAccessToken();
         }
 

--- a/src/Facebook/FacebookRequest.php
+++ b/src/Facebook/FacebookRequest.php
@@ -294,7 +294,7 @@ class FacebookRequest
             $headers['If-None-Match'] = $this->eTag;
         }
 
-        return array_merge($this->headers, $headers);
+        return \array_merge($this->headers, $headers);
     }
 
     /**
@@ -304,7 +304,7 @@ class FacebookRequest
      */
     public function setHeaders(array $headers)
     {
-        $this->headers = array_merge($this->headers, $headers);
+        $this->headers = \array_merge($this->headers, $headers);
     }
 
     /**
@@ -352,7 +352,7 @@ class FacebookRequest
      */
     public function dangerouslySetParams(array $params = [])
     {
-        $this->params = array_merge($this->params, $params);
+        $this->params = \array_merge($this->params, $params);
 
         return $this;
     }

--- a/src/Facebook/FacebookResponse.php
+++ b/src/Facebook/FacebookResponse.php
@@ -233,21 +233,21 @@ class FacebookResponse
      */
     public function decodeBody()
     {
-        $this->decodedBody = json_decode($this->body, true);
+        $this->decodedBody = \json_decode($this->body, true);
 
         if ($this->decodedBody === null) {
             $this->decodedBody = [];
-            parse_str($this->body, $this->decodedBody);
-        } elseif (is_bool($this->decodedBody)) {
+            \parse_str($this->body, $this->decodedBody);
+        } elseif (\is_bool($this->decodedBody)) {
             // Backwards compatibility for Graph < 2.1.
             // Mimics 2.1 responses.
             // @TODO Remove this after Graph 2.0 is no longer supported
             $this->decodedBody = ['success' => $this->decodedBody];
-        } elseif (is_numeric($this->decodedBody)) {
+        } elseif (\is_numeric($this->decodedBody)) {
             $this->decodedBody = ['id' => $this->decodedBody];
         }
 
-        if (!is_array($this->decodedBody)) {
+        if (!\is_array($this->decodedBody)) {
             $this->decodedBody = [];
         }
 

--- a/src/Facebook/FileUpload/FacebookFile.php
+++ b/src/Facebook/FileUpload/FacebookFile.php
@@ -84,11 +84,11 @@ class FacebookFile
      */
     public function open()
     {
-        if (!$this->isRemoteFile($this->path) && !is_readable($this->path)) {
+        if (!$this->isRemoteFile($this->path) && !\is_readable($this->path)) {
             throw new FacebookSDKException('Failed to create FacebookFile entity. Unable to read resource: ' . $this->path . '.');
         }
 
-        $this->stream = fopen($this->path, 'r');
+        $this->stream = \fopen($this->path, 'r');
 
         if (!$this->stream) {
             throw new FacebookSDKException('Failed to create FacebookFile entity. Unable to open resource: ' . $this->path . '.');
@@ -100,8 +100,8 @@ class FacebookFile
      */
     public function close()
     {
-        if (is_resource($this->stream)) {
-            fclose($this->stream);
+        if (\is_resource($this->stream)) {
+            \fclose($this->stream);
         }
     }
 
@@ -112,7 +112,7 @@ class FacebookFile
      */
     public function getContents()
     {
-        return stream_get_contents($this->stream, $this->maxLength, $this->offset);
+        return \stream_get_contents($this->stream, $this->maxLength, $this->offset);
     }
 
     /**
@@ -122,7 +122,7 @@ class FacebookFile
      */
     public function getFileName()
     {
-        return basename($this->path);
+        return \basename($this->path);
     }
 
     /**
@@ -142,7 +142,7 @@ class FacebookFile
      */
     public function getSize()
     {
-        return filesize($this->path);
+        return \filesize($this->path);
     }
 
     /**
@@ -164,6 +164,6 @@ class FacebookFile
      */
     protected function isRemoteFile($pathToFile)
     {
-        return preg_match('/^(https?|ftp):\/\/.*/', $pathToFile) === 1;
+        return \preg_match('/^(https?|ftp):\/\/.*/', $pathToFile) === 1;
     }
 }

--- a/src/Facebook/FileUpload/FacebookResumableUploader.php
+++ b/src/Facebook/FileUpload/FacebookResumableUploader.php
@@ -141,7 +141,7 @@ class FacebookResumableUploader
      */
     public function finish($endpoint, $uploadSessionId, $metadata = [])
     {
-        $params = array_merge($metadata, [
+        $params = \array_merge($metadata, [
             'upload_phase' => 'finish',
             'upload_session_id' => $uploadSessionId,
         ]);

--- a/src/Facebook/FileUpload/Mimetypes.php
+++ b/src/Facebook/FileUpload/Mimetypes.php
@@ -969,7 +969,7 @@ class Mimetypes
      */
     public function fromExtension($extension)
     {
-        $extension = strtolower($extension);
+        $extension = \strtolower($extension);
 
         return isset($this->mimetypes[$extension]) ? $this->mimetypes[$extension] : null;
     }
@@ -983,6 +983,6 @@ class Mimetypes
      */
     public function fromFilename($filename)
     {
-        return $this->fromExtension(pathinfo($filename, PATHINFO_EXTENSION));
+        return $this->fromExtension(\pathinfo($filename, PATHINFO_EXTENSION));
     }
 }

--- a/src/Facebook/GraphNodes/Birthday.php
+++ b/src/Facebook/GraphNodes/Birthday.php
@@ -55,10 +55,10 @@ class Birthday extends DateTime
      */
     public function __construct($date)
     {
-        $parts = explode('/', $date);
+        $parts = \explode('/', $date);
 
-        $this->hasYear = count($parts) === 3 || count($parts) === 1;
-        $this->hasDate = count($parts) === 3 || count($parts) === 2;
+        $this->hasYear = \count($parts) === 3 || \count($parts) === 1;
+        $this->hasDate = \count($parts) === 3 || \count($parts) === 2;
 
         parent::__construct($date);
     }

--- a/src/Facebook/GraphNodes/Collection.php
+++ b/src/Facebook/GraphNodes/Collection.php
@@ -95,7 +95,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
      */
     public function getFieldNames()
     {
-        return array_keys($this->items);
+        return \array_keys($this->items);
     }
 
     /**
@@ -128,7 +128,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
      */
     public function asArray()
     {
-        return array_map(function ($value) {
+        return \array_map(function ($value) {
             return $value instanceof Collection ? $value->asArray() : $value;
         }, $this->items);
     }
@@ -142,7 +142,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
      */
     public function map(\Closure $callback)
     {
-        return new static(array_map($callback, $this->items, array_keys($this->items)));
+        return new static(\array_map($callback, $this->items, \array_keys($this->items)));
     }
 
     /**
@@ -154,7 +154,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
      */
     public function asJson($options = 0)
     {
-        return json_encode($this->asArray(), $options);
+        return \json_encode($this->asArray(), $options);
     }
 
     /**
@@ -164,7 +164,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
      */
     public function count()
     {
-        return count($this->items);
+        return \count($this->items);
     }
 
     /**
@@ -186,7 +186,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
      */
     public function offsetExists($key)
     {
-        return array_key_exists($key, $this->items);
+        return \array_key_exists($key, $this->items);
     }
 
     /**
@@ -211,7 +211,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
      */
     public function offsetSet($key, $value)
     {
-        if (is_null($key)) {
+        if (\is_null($key)) {
             $this->items[] = $value;
         } else {
             $this->items[$key] = $value;

--- a/src/Facebook/GraphNodes/GraphEdge.php
+++ b/src/Facebook/GraphNodes/GraphEdge.php
@@ -243,7 +243,7 @@ class GraphEdge extends Collection
     {
         return new static(
             $this->request,
-            array_map($callback, $this->items, array_keys($this->items)),
+            \array_map($callback, $this->items, \array_keys($this->items)),
             $this->metaData,
             $this->parentEdgeEndpoint,
             $this->subclassName

--- a/src/Facebook/GraphNodes/GraphNode.php
+++ b/src/Facebook/GraphNodes/GraphNode.php
@@ -61,7 +61,7 @@ class GraphNode extends Collection
 
         foreach ($data as $k => $v) {
             if ($this->shouldCastAsDateTime($k)
-                && (is_numeric($v)
+                && (\is_numeric($v)
                     || $this->isIso8601DateString($v))
             ) {
                 $items[$k] = $this->castToDateTime($v);
@@ -85,7 +85,7 @@ class GraphNode extends Collection
     {
         $items = $this->asArray();
 
-        return array_map(function ($v) {
+        return \array_map(function ($v) {
             if ($v instanceof \DateTime) {
                 return $v->format(\DateTime::ISO8601);
             }
@@ -103,7 +103,7 @@ class GraphNode extends Collection
      */
     public function asJson($options = 0)
     {
-        return json_encode($this->uncastItems(), $options);
+        return \json_encode($this->uncastItems(), $options);
     }
 
     /**
@@ -130,7 +130,7 @@ class GraphNode extends Collection
             . '((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d'
             . '([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$/';
 
-        return preg_match($crazyInsaneRegexThatSomehowDetectsIso8601, $string) === 1;
+        return \preg_match($crazyInsaneRegexThatSomehowDetectsIso8601, $string) === 1;
     }
 
     /**
@@ -142,7 +142,7 @@ class GraphNode extends Collection
      */
     public function shouldCastAsDateTime($key)
     {
-        return in_array($key, [
+        return \in_array($key, [
             'created_time',
             'updated_time',
             'start_time',
@@ -163,7 +163,7 @@ class GraphNode extends Collection
      */
     public function castToDateTime($value)
     {
-        if (is_int($value)) {
+        if (\is_int($value)) {
             $dt = new \DateTime();
             $dt->setTimestamp($value);
         } else {

--- a/src/Facebook/GraphNodes/GraphNodeFactory.php
+++ b/src/Facebook/GraphNodes/GraphNodeFactory.php
@@ -208,7 +208,7 @@ class GraphNodeFactory
      */
     public function validateResponseAsArray()
     {
-        if (!is_array($this->decodedBody)) {
+        if (!\is_array($this->decodedBody)) {
             throw new FacebookSDKException('Unable to get response from Graph as array.', 620);
         }
     }
@@ -265,7 +265,7 @@ class GraphNodeFactory
 
         foreach ($data as $k => $v) {
             // Array means could be recurable
-            if (is_array($v)) {
+            if (\is_array($v)) {
                 // Detect any smart-casting from the $graphObjectMap array.
                 // This is always empty on the GraphNode collection, but subclasses can define
                 // their own array of smart-casting types.
@@ -371,7 +371,7 @@ class GraphNodeFactory
         }
 
         // Checks for a sequential numeric array which would be a GraphEdge
-        return array_keys($data) === range(0, count($data) - 1);
+        return \array_keys($data) === \range(0, count($data) - 1);
     }
 
     /**
@@ -383,7 +383,7 @@ class GraphNodeFactory
      */
     public static function validateSubclass($subclassName)
     {
-        if ($subclassName == static::BASE_GRAPH_NODE_CLASS || is_subclass_of($subclassName, static::BASE_GRAPH_NODE_CLASS)) {
+        if ($subclassName == static::BASE_GRAPH_NODE_CLASS || \is_subclass_of($subclassName, static::BASE_GRAPH_NODE_CLASS)) {
             return;
         }
 

--- a/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
@@ -168,7 +168,7 @@ class FacebookRedirectLoginHelper
             'access_token' => $accessToken->getValue(),
         ];
 
-        return 'https://www.facebook.com/logout.php?' . http_build_query($params, null, $separator);
+        return 'https://www.facebook.com/logout.php?' . \http_build_query($params, null, $separator);
     }
 
     /**

--- a/src/Facebook/Http/GraphRawResponse.php
+++ b/src/Facebook/Http/GraphRawResponse.php
@@ -54,11 +54,11 @@ class GraphRawResponse
      */
     public function __construct($headers, $body, $httpStatusCode = null)
     {
-        if (is_numeric($httpStatusCode)) {
+        if (\is_numeric($httpStatusCode)) {
             $this->httpResponseCode = (int)$httpStatusCode;
         }
 
-        if (is_array($headers)) {
+        if (\is_array($headers)) {
             $this->headers = $headers;
         } else {
             $this->setHeadersFromString($headers);
@@ -104,7 +104,7 @@ class GraphRawResponse
      */
     public function setHttpResponseCodeFromHeader($rawResponseHeader)
     {
-        preg_match('|HTTP/\d\.\d\s+(\d+)\s+.*|', $rawResponseHeader, $match);
+        \preg_match('|HTTP/\d\.\d\s+(\d+)\s+.*|', $rawResponseHeader, $match);
         $this->httpResponseCode = (int)$match[1];
     }
 
@@ -116,20 +116,20 @@ class GraphRawResponse
     protected function setHeadersFromString($rawHeaders)
     {
         // Normalize line breaks
-        $rawHeaders = str_replace("\r\n", "\n", $rawHeaders);
+        $rawHeaders = \str_replace("\r\n", "\n", $rawHeaders);
 
         // There will be multiple headers if a 301 was followed
         // or a proxy was followed, etc
-        $headerCollection = explode("\n\n", trim($rawHeaders));
+        $headerCollection = \explode("\n\n", trim($rawHeaders));
         // We just want the last response (at the end)
-        $rawHeader = array_pop($headerCollection);
+        $rawHeader = \array_pop($headerCollection);
 
-        $headerComponents = explode("\n", $rawHeader);
+        $headerComponents = \explode("\n", $rawHeader);
         foreach ($headerComponents as $line) {
-            if (strpos($line, ': ') === false) {
+            if (\strpos($line, ': ') === false) {
                 $this->setHttpResponseCodeFromHeader($line);
             } else {
-                list($key, $value) = explode(': ', $line, 2);
+                list($key, $value) = \explode(': ', $line, 2);
                 $this->headers[$key] = $value;
             }
         }

--- a/src/Facebook/Http/RequestBodyMultipart.php
+++ b/src/Facebook/Http/RequestBodyMultipart.php
@@ -60,7 +60,7 @@ class RequestBodyMultipart implements RequestBodyInterface
     {
         $this->params = $params;
         $this->files = $files;
-        $this->boundary = $boundary ?: uniqid();
+        $this->boundary = $boundary ?: \uniqid();
     }
 
     /**
@@ -107,7 +107,7 @@ class RequestBodyMultipart implements RequestBodyInterface
      */
     private function getFileString($name, FacebookFile $file)
     {
-        return sprintf(
+        return \sprintf(
             "--%s\r\nContent-Disposition: form-data; name=\"%s\"; filename=\"%s\"%s\r\n\r\n%s\r\n",
             $this->boundary,
             $name,
@@ -127,7 +127,7 @@ class RequestBodyMultipart implements RequestBodyInterface
      */
     private function getParamString($name, $value)
     {
-        return sprintf(
+        return \sprintf(
             "--%s\r\nContent-Disposition: form-data; name=\"%s\"\r\n\r\n%s\r\n",
             $this->boundary,
             $name,
@@ -144,13 +144,13 @@ class RequestBodyMultipart implements RequestBodyInterface
      */
     private function getNestedParams(array $params)
     {
-        $query = http_build_query($params, null, '&');
-        $params = explode('&', $query);
+        $query = \http_build_query($params, null, '&');
+        $params = \explode('&', $query);
         $result = [];
 
         foreach ($params as $param) {
-            list($key, $value) = explode('=', $param, 2);
-            $result[urldecode($key)] = urldecode($value);
+            list($key, $value) = \explode('=', $param, 2);
+            $result[\urldecode($key)] = \urldecode($value);
         }
 
         return $result;

--- a/src/Facebook/Http/RequestBodyUrlEncoded.php
+++ b/src/Facebook/Http/RequestBodyUrlEncoded.php
@@ -50,6 +50,6 @@ class RequestBodyUrlEncoded implements RequestBodyInterface
      */
     public function getBody()
     {
-        return http_build_query($this->params, null, '&');
+        return \http_build_query($this->params, null, '&');
     }
 }

--- a/src/Facebook/HttpClients/FacebookCurl.php
+++ b/src/Facebook/HttpClients/FacebookCurl.php
@@ -43,7 +43,7 @@ class FacebookCurl
      */
     public function init()
     {
-        $this->curl = curl_init();
+        $this->curl = \curl_init();
     }
 
     /**
@@ -54,7 +54,7 @@ class FacebookCurl
      */
     public function setopt($key, $value)
     {
-        curl_setopt($this->curl, $key, $value);
+        \curl_setopt($this->curl, $key, $value);
     }
 
     /**
@@ -64,7 +64,7 @@ class FacebookCurl
      */
     public function setoptArray(array $options)
     {
-        curl_setopt_array($this->curl, $options);
+        \curl_setopt_array($this->curl, $options);
     }
 
     /**
@@ -74,7 +74,7 @@ class FacebookCurl
      */
     public function exec()
     {
-        return curl_exec($this->curl);
+        return \curl_exec($this->curl);
     }
 
     /**
@@ -84,7 +84,7 @@ class FacebookCurl
      */
     public function errno()
     {
-        return curl_errno($this->curl);
+        return \curl_errno($this->curl);
     }
 
     /**
@@ -94,7 +94,7 @@ class FacebookCurl
      */
     public function error()
     {
-        return curl_error($this->curl);
+        return \curl_error($this->curl);
     }
 
     /**
@@ -106,7 +106,7 @@ class FacebookCurl
      */
     public function getinfo($type)
     {
-        return curl_getinfo($this->curl, $type);
+        return \curl_getinfo($this->curl, $type);
     }
 
     /**
@@ -116,7 +116,7 @@ class FacebookCurl
      */
     public function version()
     {
-        return curl_version();
+        return \curl_version();
     }
 
     /**
@@ -124,6 +124,6 @@ class FacebookCurl
      */
     public function close()
     {
-        curl_close($this->curl);
+        \curl_close($this->curl);
     }
 }

--- a/src/Facebook/HttpClients/FacebookCurlHttpClient.php
+++ b/src/Facebook/HttpClients/FacebookCurlHttpClient.php
@@ -154,10 +154,10 @@ class FacebookCurlHttpClient implements FacebookHttpClientInterface
      */
     public function extractResponseHeadersAndBody()
     {
-        $parts = explode("\r\n\r\n", $this->rawResponse);
-        $rawBody = array_pop($parts);
-        $rawHeaders = implode("\r\n\r\n", $parts);
+        $parts = \explode("\r\n\r\n", $this->rawResponse);
+        $rawBody = \array_pop($parts);
+        $rawHeaders = \implode("\r\n\r\n", $parts);
 
-        return [trim($rawHeaders), trim($rawBody)];
+        return [\trim($rawHeaders), \trim($rawBody)];
     }
 }

--- a/src/Facebook/HttpClients/FacebookGuzzleHttpClient.php
+++ b/src/Facebook/HttpClients/FacebookGuzzleHttpClient.php
@@ -89,9 +89,9 @@ class FacebookGuzzleHttpClient implements FacebookHttpClientInterface
         $headers = $response->getHeaders();
         $rawHeaders = [];
         foreach ($headers as $name => $values) {
-            $rawHeaders[] = $name . ": " . implode(", ", $values);
+            $rawHeaders[] = $name . ": " . \implode(", ", $values);
         }
 
-        return implode("\r\n", $rawHeaders);
+        return \implode("\r\n", $rawHeaders);
     }
 }

--- a/src/Facebook/HttpClients/FacebookStream.php
+++ b/src/Facebook/HttpClients/FacebookStream.php
@@ -50,7 +50,7 @@ class FacebookStream
      */
     public function streamContextCreate(array $options)
     {
-        $this->stream = stream_context_create($options);
+        $this->stream = \stream_context_create($options);
     }
 
     /**
@@ -72,7 +72,7 @@ class FacebookStream
      */
     public function fileGetContents($url)
     {
-        $rawResponse = file_get_contents($url, false, $this->stream);
+        $rawResponse = \file_get_contents($url, false, $this->stream);
         $this->responseHeaders = $http_response_header ?: [];
 
         return $rawResponse;

--- a/src/Facebook/HttpClients/FacebookStreamHttpClient.php
+++ b/src/Facebook/HttpClients/FacebookStreamHttpClient.php
@@ -70,7 +70,7 @@ class FacebookStreamHttpClient implements FacebookHttpClientInterface
             throw new FacebookSDKException('Stream returned an empty response', 660);
         }
 
-        $rawHeaders = implode("\r\n", $rawHeaders);
+        $rawHeaders = \implode("\r\n", $rawHeaders);
 
         return new GraphRawResponse($rawHeaders, $rawBody);
     }
@@ -89,6 +89,6 @@ class FacebookStreamHttpClient implements FacebookHttpClientInterface
             $header[] = $k . ': ' . $v;
         }
 
-        return implode("\r\n", $header);
+        return \implode("\r\n", $header);
     }
 }

--- a/src/Facebook/HttpClients/HttpClientsFactory.php
+++ b/src/Facebook/HttpClients/HttpClientsFactory.php
@@ -58,14 +58,14 @@ class HttpClientsFactory
             return new FacebookStreamHttpClient();
         }
         if ('curl' === $handler) {
-            if (!extension_loaded('curl')) {
+            if (!\extension_loaded('curl')) {
                 throw new Exception('The cURL extension must be loaded in order to use the "curl" handler.');
             }
 
             return new FacebookCurlHttpClient();
         }
 
-        if ('guzzle' === $handler && !class_exists('GuzzleHttp\Client')) {
+        if ('guzzle' === $handler && !\class_exists('GuzzleHttp\Client')) {
             throw new Exception('The Guzzle HTTP client must be included in order to use the "guzzle" handler.');
         }
 
@@ -86,11 +86,11 @@ class HttpClientsFactory
      */
     private static function detectDefaultClient()
     {
-        if (extension_loaded('curl')) {
+        if (\extension_loaded('curl')) {
             return new FacebookCurlHttpClient();
         }
 
-        if (class_exists('GuzzleHttp\Client')) {
+        if (\class_exists('GuzzleHttp\Client')) {
             return new FacebookGuzzleHttpClient();
         }
 

--- a/src/Facebook/PersistentData/FacebookSessionPersistentDataHandler.php
+++ b/src/Facebook/PersistentData/FacebookSessionPersistentDataHandler.php
@@ -46,7 +46,7 @@ class FacebookSessionPersistentDataHandler implements PersistentDataInterface
      */
     public function __construct($enableSessionCheck = true)
     {
-        if ($enableSessionCheck && session_status() !== PHP_SESSION_ACTIVE) {
+        if ($enableSessionCheck && \session_status() !== PHP_SESSION_ACTIVE) {
             throw new FacebookSDKException(
                 'Sessions are not active. Please make sure session_start() is at the top of your script.',
                 720

--- a/src/Facebook/PersistentData/PersistentDataFactory.php
+++ b/src/Facebook/PersistentData/PersistentDataFactory.php
@@ -44,7 +44,7 @@ class PersistentDataFactory
     public static function createPersistentDataHandler($handler)
     {
         if (!$handler) {
-            return session_status() === PHP_SESSION_ACTIVE
+            return \session_status() === PHP_SESSION_ACTIVE
                 ? new FacebookSessionPersistentDataHandler()
                 : new FacebookMemoryPersistentDataHandler();
         }

--- a/src/Facebook/PseudoRandomString/McryptPseudoRandomStringGenerator.php
+++ b/src/Facebook/PseudoRandomString/McryptPseudoRandomStringGenerator.php
@@ -39,7 +39,7 @@ class McryptPseudoRandomStringGenerator implements PseudoRandomStringGeneratorIn
      */
     public function __construct()
     {
-        if (!function_exists('mcrypt_create_iv')) {
+        if (!\function_exists('mcrypt_create_iv')) {
             throw new FacebookSDKException(
                 static::ERROR_MESSAGE .
                 'The function mcrypt_create_iv() does not exist.'
@@ -54,7 +54,7 @@ class McryptPseudoRandomStringGenerator implements PseudoRandomStringGeneratorIn
     {
         $this->validateLength($length);
 
-        $binaryString = mcrypt_create_iv($length, MCRYPT_DEV_URANDOM);
+        $binaryString = \mcrypt_create_iv($length, MCRYPT_DEV_URANDOM);
 
         if ($binaryString === false) {
             throw new FacebookSDKException(

--- a/src/Facebook/PseudoRandomString/OpenSslPseudoRandomStringGenerator.php
+++ b/src/Facebook/PseudoRandomString/OpenSslPseudoRandomStringGenerator.php
@@ -39,7 +39,7 @@ class OpenSslPseudoRandomStringGenerator implements PseudoRandomStringGeneratorI
      */
     public function __construct()
     {
-        if (!function_exists('openssl_random_pseudo_bytes')) {
+        if (!\function_exists('openssl_random_pseudo_bytes')) {
             throw new FacebookSDKException(static::ERROR_MESSAGE . 'The function openssl_random_pseudo_bytes() does not exist.');
         }
     }
@@ -52,7 +52,7 @@ class OpenSslPseudoRandomStringGenerator implements PseudoRandomStringGeneratorI
         $this->validateLength($length);
 
         $wasCryptographicallyStrong = false;
-        $binaryString = openssl_random_pseudo_bytes($length, $wasCryptographicallyStrong);
+        $binaryString = \openssl_random_pseudo_bytes($length, $wasCryptographicallyStrong);
 
         if ($binaryString === false) {
             throw new FacebookSDKException(static::ERROR_MESSAGE . 'openssl_random_pseudo_bytes() returned an unknown error.');

--- a/src/Facebook/PseudoRandomString/PseudoRandomStringGeneratorFactory.php
+++ b/src/Facebook/PseudoRandomString/PseudoRandomStringGeneratorFactory.php
@@ -78,21 +78,21 @@ class PseudoRandomStringGeneratorFactory
     private static function detectDefaultPseudoRandomStringGenerator()
     {
         // Check for PHP 7's CSPRNG first to keep mcrypt deprecation messages from appearing in PHP 7.1.
-        if (function_exists('random_bytes')) {
+        if (\function_exists('random_bytes')) {
             return new RandomBytesPseudoRandomStringGenerator();
         }
 
         // Since openssl_random_pseudo_bytes() can sometimes return non-cryptographically
         // secure pseudo-random strings (in rare cases), we check for mcrypt_create_iv() next.
-        if (function_exists('mcrypt_create_iv')) {
+        if (\function_exists('mcrypt_create_iv')) {
             return new McryptPseudoRandomStringGenerator();
         }
 
-        if (function_exists('openssl_random_pseudo_bytes')) {
+        if (\function_exists('openssl_random_pseudo_bytes')) {
             return new OpenSslPseudoRandomStringGenerator();
         }
 
-        if (!ini_get('open_basedir') && is_readable('/dev/urandom')) {
+        if (!\ini_get('open_basedir') && \is_readable('/dev/urandom')) {
             return new UrandomPseudoRandomStringGenerator();
         }
 

--- a/src/Facebook/PseudoRandomString/PseudoRandomStringGeneratorTrait.php
+++ b/src/Facebook/PseudoRandomString/PseudoRandomStringGeneratorTrait.php
@@ -34,7 +34,7 @@ trait PseudoRandomStringGeneratorTrait
      */
     public function validateLength($length)
     {
-        if (!is_int($length)) {
+        if (!\is_int($length)) {
             throw new \InvalidArgumentException('getPseudoRandomString() expects an integer for the string length');
         }
 

--- a/src/Facebook/PseudoRandomString/RandomBytesPseudoRandomStringGenerator.php
+++ b/src/Facebook/PseudoRandomString/RandomBytesPseudoRandomStringGenerator.php
@@ -39,7 +39,7 @@ class RandomBytesPseudoRandomStringGenerator implements PseudoRandomStringGenera
      */
     public function __construct()
     {
-        if (!function_exists('random_bytes')) {
+        if (!\function_exists('random_bytes')) {
             throw new FacebookSDKException(
                 static::ERROR_MESSAGE .
                 'The function random_bytes() does not exist.'
@@ -54,6 +54,6 @@ class RandomBytesPseudoRandomStringGenerator implements PseudoRandomStringGenera
     {
         $this->validateLength($length);
 
-        return $this->binToHex(random_bytes($length), $length);
+        return $this->binToHex(\random_bytes($length), $length);
     }
 }

--- a/src/Facebook/PseudoRandomString/UrandomPseudoRandomStringGenerator.php
+++ b/src/Facebook/PseudoRandomString/UrandomPseudoRandomStringGenerator.php
@@ -40,14 +40,14 @@ class UrandomPseudoRandomStringGenerator implements PseudoRandomStringGeneratorI
      */
     public function __construct()
     {
-        if (ini_get('open_basedir')) {
+        if (\ini_get('open_basedir')) {
             throw new FacebookSDKException(
                 static::ERROR_MESSAGE .
                 'There is an open_basedir constraint that prevents access to /dev/urandom.'
             );
         }
 
-        if (!is_readable('/dev/urandom')) {
+        if (!\is_readable('/dev/urandom')) {
             throw new FacebookSDKException(
                 static::ERROR_MESSAGE .
                 'Unable to read from /dev/urandom.'
@@ -62,20 +62,20 @@ class UrandomPseudoRandomStringGenerator implements PseudoRandomStringGeneratorI
     {
         $this->validateLength($length);
 
-        $stream = fopen('/dev/urandom', 'rb');
-        if (!is_resource($stream)) {
+        $stream = \fopen('/dev/urandom', 'rb');
+        if (!\is_resource($stream)) {
             throw new FacebookSDKException(
                 static::ERROR_MESSAGE .
                 'Unable to open stream to /dev/urandom.'
             );
         }
 
-        if (!defined('HHVM_VERSION')) {
-            stream_set_read_buffer($stream, 0);
+        if (!\defined('HHVM_VERSION')) {
+            \stream_set_read_buffer($stream, 0);
         }
 
-        $binaryString = fread($stream, $length);
-        fclose($stream);
+        $binaryString = \fread($stream, $length);
+        \fclose($stream);
 
         if (!$binaryString) {
             throw new FacebookSDKException(

--- a/src/Facebook/SignedRequest.php
+++ b/src/Facebook/SignedRequest.php
@@ -133,8 +133,8 @@ class SignedRequest
     public function make(array $payload)
     {
         $payload['algorithm'] = isset($payload['algorithm']) ? $payload['algorithm'] : 'HMAC-SHA256';
-        $payload['issued_at'] = isset($payload['issued_at']) ? $payload['issued_at'] : time();
-        $encodedPayload = $this->base64UrlEncode(json_encode($payload));
+        $payload['issued_at'] = isset($payload['issued_at']) ? $payload['issued_at'] : \time();
+        $encodedPayload = $this->base64UrlEncode(\json_encode($payload));
 
         $hashedSig = $this->hashSignature($encodedPayload);
         $encodedSig = $this->base64UrlEncode($hashedSig);
@@ -170,11 +170,11 @@ class SignedRequest
      */
     protected function split()
     {
-        if (strpos($this->rawSignedRequest, '.') === false) {
+        if (\strpos($this->rawSignedRequest, '.') === false) {
             throw new FacebookSDKException('Malformed signed request.', 606);
         }
 
-        return explode('.', $this->rawSignedRequest, 2);
+        return \explode('.', $this->rawSignedRequest, 2);
     }
 
     /**
@@ -211,10 +211,10 @@ class SignedRequest
         $payload = $this->base64UrlDecode($encodedPayload);
 
         if ($payload) {
-            $payload = json_decode($payload, true);
+            $payload = \json_decode($payload, true);
         }
 
-        if (!is_array($payload)) {
+        if (!\is_array($payload)) {
             throw new FacebookSDKException('Signed request has malformed encoded payload data.', 607);
         }
 
@@ -244,7 +244,7 @@ class SignedRequest
      */
     protected function hashSignature($encodedData)
     {
-        $hashedSig = hash_hmac(
+        $hashedSig = \hash_hmac(
             'sha256',
             $encodedData,
             $this->app->getSecret(),
@@ -288,10 +288,10 @@ class SignedRequest
      */
     public function base64UrlDecode($input)
     {
-        $urlDecodedBase64 = strtr($input, '-_', '+/');
+        $urlDecodedBase64 = \strtr($input, '-_', '+/');
         $this->validateBase64($urlDecodedBase64);
 
-        return base64_decode($urlDecodedBase64);
+        return \base64_decode($urlDecodedBase64);
     }
 
     /**
@@ -307,7 +307,7 @@ class SignedRequest
      */
     public function base64UrlEncode($input)
     {
-        return strtr(base64_encode($input), '+/', '-_');
+        return \strtr(\base64_encode($input), '+/', '-_');
     }
 
     /**
@@ -319,7 +319,7 @@ class SignedRequest
      */
     protected function validateBase64($input)
     {
-        if (!preg_match('/^[a-zA-Z0-9\/\r\n+]*={0,2}$/', $input)) {
+        if (!\preg_match('/^[a-zA-Z0-9\/\r\n+]*={0,2}$/', $input)) {
             throw new FacebookSDKException('Signed request contains malformed base64 encoding.', 608);
         }
     }

--- a/src/Facebook/Url/FacebookUrlDetectionHandler.php
+++ b/src/Facebook/Url/FacebookUrlDetectionHandler.php
@@ -78,9 +78,9 @@ class FacebookUrlDetectionHandler implements UrlDetectionInterface
      */
     protected function protocolWithActiveSsl($protocol)
     {
-        $protocol = strtolower((string)$protocol);
+        $protocol = \strtolower((string)$protocol);
 
-        return in_array($protocol, ['on', '1', 'https', 'ssl'], true);
+        return \in_array($protocol, ['on', '1', 'https', 'ssl'], true);
     }
 
     /**
@@ -97,8 +97,8 @@ class FacebookUrlDetectionHandler implements UrlDetectionInterface
         // Check for proxy first
         $header = $this->getHeader('X_FORWARDED_HOST');
         if ($header && $this->isValidForwardedHost($header)) {
-            $elements = explode(',', $header);
-            $host = $elements[count($elements) - 1];
+            $elements = \explode(',', $header);
+            $host = $elements[\count($elements) - 1];
         } elseif (!$host = $this->getHeader('HOST')) {
             if (!$host = $this->getServerVar('SERVER_NAME')) {
                 $host = $this->getServerVar('SERVER_ADDR');
@@ -107,7 +107,7 @@ class FacebookUrlDetectionHandler implements UrlDetectionInterface
 
         // trim and remove port number from host
         // host is lowercase as per RFC 952/2181
-        $host = strtolower(preg_replace('/:\d+$/', '', trim($host)));
+        $host = \strtolower(\preg_replace('/:\d+$/', '', \trim($host)));
 
         // Port number
         $scheme = $this->getHttpScheme();
@@ -172,11 +172,11 @@ class FacebookUrlDetectionHandler implements UrlDetectionInterface
      */
     protected function isValidForwardedHost($header)
     {
-        $elements = explode(',', $header);
-        $host = $elements[count($elements) - 1];
+        $elements = \explode(',', $header);
+        $host = $elements[\count($elements) - 1];
         
-        return preg_match("/^([a-z\d](-*[a-z\d])*)(\.([a-z\d](-*[a-z\d])*))*$/i", $host) //valid chars check
-            && 0 < strlen($host) && strlen($host) < 254 //overall length check
-            && preg_match("/^[^\.]{1,63}(\.[^\.]{1,63})*$/", $host); //length of each label
+        return \preg_match("/^([a-z\d](-*[a-z\d])*)(\.([a-z\d](-*[a-z\d])*))*$/i", $host) //valid chars check
+            && 0 < \strlen($host) && \strlen($host) < 254 //overall length check
+            && \preg_match("/^[^\.]{1,63}(\.[^\.]{1,63})*$/", $host); //length of each label
     }
 }

--- a/src/Facebook/Url/FacebookUrlManipulator.php
+++ b/src/Facebook/Url/FacebookUrlManipulator.php
@@ -40,20 +40,20 @@ class FacebookUrlManipulator
      */
     public static function removeParamsFromUrl($url, array $paramsToFilter)
     {
-        $parts = parse_url($url);
+        $parts = \parse_url($url);
 
         $query = '';
         if (isset($parts['query'])) {
             $params = [];
-            parse_str($parts['query'], $params);
+            \parse_str($parts['query'], $params);
 
             // Remove query params
             foreach ($paramsToFilter as $paramName) {
                 unset($params[$paramName]);
             }
 
-            if (count($params) > 0) {
-                $query = '?' . http_build_query($params, null, '&');
+            if (\count($params) > 0) {
+                $query = '?' . \http_build_query($params, null, '&');
             }
         }
 
@@ -80,21 +80,21 @@ class FacebookUrlManipulator
             return $url;
         }
 
-        if (strpos($url, '?') === false) {
-            return $url . '?' . http_build_query($newParams, null, '&');
+        if (\strpos($url, '?') === false) {
+            return $url . '?' . \http_build_query($newParams, null, '&');
         }
 
-        list($path, $query) = explode('?', $url, 2);
+        list($path, $query) = \explode('?', $url, 2);
         $existingParams = [];
-        parse_str($query, $existingParams);
+        \parse_str($query, $existingParams);
 
         // Favor params from the original URL over $newParams
-        $newParams = array_merge($newParams, $existingParams);
+        $newParams = \array_merge($newParams, $existingParams);
 
         // Sort for a predicable order
-        ksort($newParams);
+        \ksort($newParams);
 
-        return $path . '?' . http_build_query($newParams, null, '&');
+        return $path . '?' . \http_build_query($newParams, null, '&');
     }
 
     /**
@@ -106,12 +106,12 @@ class FacebookUrlManipulator
      */
     public static function getParamsAsArray($url)
     {
-        $query = parse_url($url, PHP_URL_QUERY);
+        $query = \parse_url($url, PHP_URL_QUERY);
         if (!$query) {
             return [];
         }
         $params = [];
-        parse_str($query, $params);
+        \parse_str($query, $params);
 
         return $params;
     }
@@ -150,7 +150,7 @@ class FacebookUrlManipulator
             return $string;
         }
 
-        return strpos($string, '/') === 0 ? $string : '/' . $string;
+        return \strpos($string, '/') === 0 ? $string : '/' . $string;
     }
 
     /**
@@ -162,6 +162,6 @@ class FacebookUrlManipulator
      */
     public static function baseGraphUrlEndpoint($urlToTrim)
     {
-        return '/' . preg_replace('/^https:\/\/.+\.facebook\.com(\/v.+?)?\//', '', $urlToTrim);
+        return '/' . \preg_replace('/^https:\/\/.+\.facebook\.com(\/v.+?)?\//', '', $urlToTrim);
     }
 }

--- a/src/Facebook/polyfills.php
+++ b/src/Facebook/polyfills.php
@@ -25,22 +25,22 @@
 /**
  * @see https://github.com/sarciszewski/php-future/blob/master/src/Security.php#L37-L51
  */
-if (!function_exists('hash_equals')) {
+if (!\function_exists('hash_equals')) {
     function hash_equals($knownString, $userString)
     {
-        if (function_exists('mb_strlen')) {
-            $kLen = mb_strlen($knownString, '8bit');
-            $uLen = mb_strlen($userString, '8bit');
+        if (\function_exists('mb_strlen')) {
+            $kLen = \mb_strlen($knownString, '8bit');
+            $uLen = \mb_strlen($userString, '8bit');
         } else {
-            $kLen = strlen($knownString);
-            $uLen = strlen($userString);
+            $kLen = \strlen($knownString);
+            $uLen = \strlen($userString);
         }
         if ($kLen !== $uLen) {
             return false;
         }
         $result = 0;
         for ($i = 0; $i < $kLen; $i++) {
-            $result |= (ord($knownString[$i]) ^ ord($userString[$i]));
+            $result |= (\ord($knownString[$i]) ^ \ord($userString[$i]));
         }
 
         // They are only identical strings if $result is exactly 0...


### PR DESCRIPTION
I add '\\' to all functions in PHP cause generate better opcode for PHP VM in PHP 7.
Replace a call to INIT_NS_FCALL_BY_NAME to a direct call.

For example : 
If you use strlen in namespace Foo\Bar
PHP search for Foo\Bar\strlen, failed, search in Foo\strlen, failed, search in global namespace and find strlen function.
with '\\' PHP directly ask to a global namespace the function strlen.