### PR TITLE
getFanCount() method to GraphPage. (get pagelikes)

### DIFF
--- a/src/Facebook/GraphNodes/GraphPage.php
+++ b/src/Facebook/GraphNodes/GraphPage.php
@@ -144,4 +144,14 @@ class GraphPage extends GraphNode
     {
         return $this->getField('perms');
     }
+
+    /**
+     * Returns the `fan_count` (Number of people who likes to page) as int if present.
+     *
+     * @return int|null
+     */
+    public function getFanCount()
+    {
+        return $this->getField('fan_count');
+    }
 }


### PR DESCRIPTION
The GraphPage object was missing a get method for fan_count AKA page likes. So I added it.