### PR TITLE
Added Hack Compatibility

### DIFF
--- a/src/Facebook/GraphNodes/GraphCollection.php
+++ b/src/Facebook/GraphNodes/GraphCollection.php
@@ -36,7 +36,7 @@ use ArrayIterator;
 use Countable;
 use IteratorAggregate;
 
-class Collection implements ArrayAccess, Countable, IteratorAggregate
+class GraphCollection implements ArrayAccess, Countable, IteratorAggregate
 {
     /**
      * The items contained in the collection.
@@ -129,7 +129,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
     public function asArray()
     {
         return array_map(function ($value) {
-            return $value instanceof Collection ? $value->asArray() : $value;
+            return $value instanceof GraphCollection ? $value->asArray() : $value;
         }, $this->items);
     }
 

--- a/src/Facebook/GraphNodes/GraphEdge.php
+++ b/src/Facebook/GraphNodes/GraphEdge.php
@@ -32,7 +32,7 @@ use Facebook\Exceptions\FacebookSDKException;
  *
  * @package Facebook
  */
-class GraphEdge extends Collection
+class GraphEdge extends GraphCollection
 {
     /**
      * @var FacebookRequest The original request that generated this data.

--- a/src/Facebook/GraphNodes/GraphNode.php
+++ b/src/Facebook/GraphNodes/GraphNode.php
@@ -28,7 +28,7 @@ namespace Facebook\GraphNodes;
  *
  * @package Facebook
  */
-class GraphNode extends Collection
+class GraphNode extends GraphCollection
 {
     /**
      * @var array Maps object key names to Graph object types.

--- a/src/Facebook/Http/Util.php
+++ b/src/Facebook/Http/Util.php
@@ -24,7 +24,8 @@
 
 namespace Facebook\Http;
 
-abstract class Util {
+abstract class Util
+{
 
   /**
    * Avoid parse_str() for HHVM compatibility
@@ -35,14 +36,15 @@ abstract class Util {
    * @param $query_string
    * @return array
    */
-  public static function parseUrlQuery($query_string) {
-    $query = array();
-    $pairs = explode('&', $query_string);
-    foreach ($pairs as $pair) {
-      list($key, $value) = explode('=', $pair);
-      $query[$key] = urldecode($value);
-    }
+    public static function parseUrlQuery($query_string)
+    {
+        $query = array();
+        $pairs = explode('&', $query_string);
+        foreach ($pairs as $pair) {
+            list($key, $value) = explode('=', $pair);
+            $query[$key] = urldecode($value);
+        }
 
-    return $query;
-  }
+        return $query;
+    }
 }

--- a/src/Facebook/Http/Util.php
+++ b/src/Facebook/Http/Util.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+namespace Facebook\Http;
+
+abstract class Util {
+
+  /**
+   * Avoid parse_str() for HHVM compatibility
+   * This implementation is not a complete sobstitute, but covers all the
+   * requirements of the Facebook Http namespace.
+   *
+   * @see hhvm.hack.disallow_dynamic_var_env_funcs
+   * @param $query_string
+   * @return array
+   */
+  public static function parseUrlQuery($query_string) {
+    $query = array();
+    $pairs = explode('&', $query_string);
+    foreach ($pairs as $pair) {
+      list($key, $value) = explode('=', $pair);
+      $query[$key] = urldecode($value);
+    }
+
+    return $query;
+  }
+}

--- a/src/Facebook/Url/FacebookUrlManipulator.php
+++ b/src/Facebook/Url/FacebookUrlManipulator.php
@@ -45,7 +45,7 @@ class FacebookUrlManipulator
         $query = '';
         if (isset($parts['query'])) {
             $params = [];
-            parse_str($parts['query'], $params);
+            $params = Util::parseUrlQuery($parts['query']);
 
             // Remove query params
             foreach ($paramsToFilter as $paramName) {
@@ -86,7 +86,7 @@ class FacebookUrlManipulator
 
         list($path, $query) = explode('?', $url, 2);
         $existingParams = [];
-        parse_str($query, $existingParams);
+        $existingParams = Util::parseUrlQuery($query);
 
         // Favor params from the original URL over $newParams
         $newParams = array_merge($newParams, $existingParams);
@@ -111,7 +111,7 @@ class FacebookUrlManipulator
             return [];
         }
         $params = [];
-        parse_str($query, $params);
+        $params = Util::parseUrlQuery($query);
 
         return $params;
     }

--- a/src/Facebook/Url/Util.php
+++ b/src/Facebook/Url/Util.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+namespace Facebook\Url;
+
+abstract class Util {
+
+  /**
+   * Avoid parse_str() for HHVM compatibility
+   * This implementation is not a complete sobstitute, but covers all the
+   * requirements of the Facebook Url namesapce.
+   *
+   * @see hhvm.hack.disallow_dynamic_var_env_funcs
+   * @param $query_string
+   * @return array
+   */
+  public static function parseUrlQuery($query_string) {
+    $query = array();
+    $pairs = explode('&', $query_string);
+    foreach ($pairs as $pair) {
+      list($key, $value) = explode('=', $pair);
+      $query[$key] = urldecode($value);
+    }
+
+    return $query;
+  }
+}

--- a/src/Facebook/Url/Util.php
+++ b/src/Facebook/Url/Util.php
@@ -24,7 +24,8 @@
 
 namespace Facebook\Url;
 
-abstract class Util {
+abstract class Util
+{
 
   /**
    * Avoid parse_str() for HHVM compatibility
@@ -35,14 +36,15 @@ abstract class Util {
    * @param $query_string
    * @return array
    */
-  public static function parseUrlQuery($query_string) {
-    $query = array();
-    $pairs = explode('&', $query_string);
-    foreach ($pairs as $pair) {
-      list($key, $value) = explode('=', $pair);
-      $query[$key] = urldecode($value);
-    }
+    public static function parseUrlQuery($query_string)
+    {
+        $query = array();
+        $pairs = explode('&', $query_string);
+        foreach ($pairs as $pair) {
+            list($key, $value) = explode('=', $pair);
+            $query[$key] = urldecode($value);
+        }
 
-    return $query;
-  }
+        return $query;
+    }
 }

--- a/tests/GraphNodes/GraphCollectionTest.php
+++ b/tests/GraphNodes/GraphCollectionTest.php
@@ -23,14 +23,14 @@
  */
 namespace Facebook\Tests\GraphNodes;
 
-use Facebook\GraphNodes\Collection;
+use Facebook\GraphNodes\GraphCollection;
 
 class CollectionTest extends \PHPUnit_Framework_TestCase
 {
 
     public function testAnExistingPropertyCanBeAccessed()
     {
-        $graphNode = new Collection(['foo' => 'bar']);
+        $graphNode = new GraphCollection(['foo' => 'bar']);
 
         $field = $graphNode->getField('foo');
         $this->assertEquals('bar', $field);
@@ -42,7 +42,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testAMissingPropertyWillReturnNull()
     {
-        $graphNode = new Collection(['foo' => 'bar']);
+        $graphNode = new GraphCollection(['foo' => 'bar']);
         $field = $graphNode->getField('baz');
 
         $this->assertNull($field, 'Expected the property to return null.');
@@ -50,7 +50,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testAMissingPropertyWillReturnTheDefault()
     {
-        $graphNode = new Collection(['foo' => 'bar']);
+        $graphNode = new GraphCollection(['foo' => 'bar']);
 
         $field = $graphNode->getField('baz', 'faz');
         $this->assertEquals('faz', $field);
@@ -62,7 +62,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testFalseDefaultsWillReturnSameType()
     {
-        $graphNode = new Collection(['foo' => 'bar']);
+        $graphNode = new GraphCollection(['foo' => 'bar']);
 
         $field = $graphNode->getField('baz', '');
         $this->assertSame('', $field);
@@ -76,7 +76,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testTheKeysFromTheCollectionCanBeReturned()
     {
-        $graphNode = new Collection([
+        $graphNode = new GraphCollection([
             'key1' => 'foo',
             'key2' => 'bar',
             'key3' => 'baz',
@@ -92,13 +92,13 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testAnArrayCanBeInjectedViaTheConstructor()
     {
-        $collection = new Collection(['foo', 'bar']);
+        $collection = new GraphCollection(['foo', 'bar']);
         $this->assertEquals(['foo', 'bar'], $collection->asArray());
     }
 
     public function testACollectionCanBeConvertedToProperJson()
     {
-        $collection = new Collection(['foo', 'bar', 123]);
+        $collection = new GraphCollection(['foo', 'bar', 123]);
 
         $collectionAsString = $collection->asJson();
 
@@ -107,7 +107,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testACollectionCanBeCounted()
     {
-        $collection = new Collection(['foo', 'bar', 'baz']);
+        $collection = new GraphCollection(['foo', 'bar', 'baz']);
 
         $collectionCount = count($collection);
 
@@ -116,7 +116,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testACollectionCanBeAccessedAsAnArray()
     {
-        $collection = new Collection(['foo' => 'bar', 'faz' => 'baz']);
+        $collection = new GraphCollection(['foo' => 'bar', 'faz' => 'baz']);
 
         $this->assertEquals('bar', $collection['foo']);
         $this->assertEquals('baz', $collection['faz']);
@@ -124,7 +124,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testACollectionCanBeIteratedOver()
     {
-        $collection = new Collection(['foo' => 'bar', 'faz' => 'baz']);
+        $collection = new GraphCollection(['foo' => 'bar', 'faz' => 'baz']);
 
         $this->assertInstanceOf('IteratorAggregate', $collection);
 


### PR DESCRIPTION
* The Collection class had a namespace conflict with Hack's `HH\Collection` (https://docs.hhvm.com/hack/reference/interface/HH.Collection/).  As a result, the Collection class has been renamed to GraphCollection.

* The `parse_str()` PHP function is disabled by default in Hack due to security concerns.  Furthermore, PHP is deprecating the function in PHP 7.2+.  As a result, the usage of `parse_str()` has been replaced with a `Util` class and `parseUrlQuery()` method.  This solution was pulled from [facebook/facebook-php-ads-sdk](https://github.com/facebook/facebook-php-ads-sdk) ([FacebookAds/Http/Util.php](https://github.com/facebook/facebook-php-ads-sdk/blob/master/src/FacebookAds/Http/Util.php)).

* Fixes #853 - For the 5.x branch