### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/tests/Authentication/AccessTokenMetadataTest.php
+++ b/tests/Authentication/AccessTokenMetadataTest.php
@@ -24,8 +24,9 @@
 namespace Facebook\Tests\Authentication;
 
 use Facebook\Authentication\AccessTokenMetadata;
+use PHPUnit\Framework\TestCase;
 
-class AccessTokenMetadataTest extends \PHPUnit_Framework_TestCase
+class AccessTokenMetadataTest extends TestCase
 {
 
     protected $graphResponseData = [

--- a/tests/Authentication/AccessTokenTest.php
+++ b/tests/Authentication/AccessTokenTest.php
@@ -24,8 +24,9 @@
 namespace Facebook\Tests\Authentication;
 
 use Facebook\Authentication\AccessToken;
+use PHPUnit\Framework\TestCase;
 
-class AccessTokenTest extends \PHPUnit_Framework_TestCase
+class AccessTokenTest extends TestCase
 {
 
     public function testAnAccessTokenCanBeReturnedAsAString()

--- a/tests/Authentication/OAuth2ClientTest.php
+++ b/tests/Authentication/OAuth2ClientTest.php
@@ -26,8 +26,9 @@ namespace Facebook\Tests\Authentication;
 use Facebook\Facebook;
 use Facebook\FacebookApp;
 use Facebook\Authentication\OAuth2Client;
+use PHPUnit\Framework\TestCase;
 
-class OAuth2ClientTest extends \PHPUnit_Framework_TestCase
+class OAuth2ClientTest extends TestCase
 {
 
     /**

--- a/tests/Exceptions/FacebookResponseExceptionTest.php
+++ b/tests/Exceptions/FacebookResponseExceptionTest.php
@@ -27,8 +27,9 @@ use Facebook\FacebookApp;
 use Facebook\FacebookRequest;
 use Facebook\FacebookResponse;
 use Facebook\Exceptions\FacebookResponseException;
+use PHPUnit\Framework\TestCase;
 
-class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
+class FacebookResponseExceptionTest extends TestCase
 {
 
     /**

--- a/tests/FacebookAppTest.php
+++ b/tests/FacebookAppTest.php
@@ -24,8 +24,9 @@
 namespace Facebook\Tests;
 
 use Facebook\FacebookApp;
+use PHPUnit\Framework\TestCase;
 
-class FacebookAppTest extends \PHPUnit_Framework_TestCase
+class FacebookAppTest extends TestCase
 {
     /**
      * @var FacebookApp

--- a/tests/FacebookBatchRequestTest.php
+++ b/tests/FacebookBatchRequestTest.php
@@ -28,8 +28,9 @@ use Facebook\FacebookApp;
 use Facebook\FacebookRequest;
 use Facebook\FacebookBatchRequest;
 use Facebook\FileUpload\FacebookFile;
+use PHPUnit\Framework\TestCase;
 
-class FacebookBatchRequestTest extends \PHPUnit_Framework_TestCase
+class FacebookBatchRequestTest extends TestCase
 {
     /**
      * @var FacebookApp

--- a/tests/FacebookBatchResponseTest.php
+++ b/tests/FacebookBatchResponseTest.php
@@ -28,8 +28,9 @@ use Facebook\FacebookRequest;
 use Facebook\FacebookResponse;
 use Facebook\FacebookBatchRequest;
 use Facebook\FacebookBatchResponse;
+use PHPUnit\Framework\TestCase;
 
-class FacebookBatchResponseTest extends \PHPUnit_Framework_TestCase
+class FacebookBatchResponseTest extends TestCase
 {
     /**
      * @var \Facebook\FacebookApp

--- a/tests/FacebookClientTest.php
+++ b/tests/FacebookClientTest.php
@@ -37,8 +37,9 @@ use Facebook\HttpClients\FacebookGuzzleHttpClient;
 use Facebook\HttpClients\FacebookStreamHttpClient;
 use Facebook\Tests\Fixtures\MyFooBatchClientHandler;
 use Facebook\Tests\Fixtures\MyFooClientHandler;
+use PHPUnit\Framework\TestCase;
 
-class FacebookClientTest extends \PHPUnit_Framework_TestCase
+class FacebookClientTest extends TestCase
 {
     /**
      * @var FacebookApp

--- a/tests/FacebookRequestTest.php
+++ b/tests/FacebookRequestTest.php
@@ -28,8 +28,9 @@ use Facebook\FacebookApp;
 use Facebook\FacebookRequest;
 use Facebook\FileUpload\FacebookFile;
 use Facebook\FileUpload\FacebookVideo;
+use PHPUnit\Framework\TestCase;
 
-class FacebookRequestTest extends \PHPUnit_Framework_TestCase
+class FacebookRequestTest extends TestCase
 {
     public function testAnEmptyRequestEntityCanInstantiate()
     {

--- a/tests/FacebookResponseTest.php
+++ b/tests/FacebookResponseTest.php
@@ -26,8 +26,9 @@ namespace Facebook\Tests;
 use Facebook\FacebookApp;
 use Facebook\FacebookRequest;
 use Facebook\FacebookResponse;
+use PHPUnit\Framework\TestCase;
 
-class FacebookResponseTest extends \PHPUnit_Framework_TestCase
+class FacebookResponseTest extends TestCase
 {
     /**
      * @var \Facebook\FacebookRequest

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -33,8 +33,9 @@ use Facebook\Tests\Fixtures\FooBarPseudoRandomStringGenerator;
 use Facebook\Tests\Fixtures\FooClientInterface;
 use Facebook\Tests\Fixtures\FooPersistentDataInterface;
 use Facebook\Tests\Fixtures\FooUrlDetectionInterface;
+use PHPUnit\Framework\TestCase;
 
-class FacebookTest extends \PHPUnit_Framework_TestCase
+class FacebookTest extends TestCase
 {
     protected $config = [
         'app_id' => '1337',

--- a/tests/FileUpload/FacebookFileTest.php
+++ b/tests/FileUpload/FacebookFileTest.php
@@ -24,8 +24,9 @@
 namespace Facebook\Tests\FileUpload;
 
 use Facebook\FileUpload\FacebookFile;
+use PHPUnit\Framework\TestCase;
 
-class FacebookFileTest extends \PHPUnit_Framework_TestCase
+class FacebookFileTest extends TestCase
 {
     protected $testFile = '';
 

--- a/tests/FileUpload/FacebookResumableUploaderTest.php
+++ b/tests/FileUpload/FacebookResumableUploaderTest.php
@@ -30,8 +30,9 @@ use Facebook\FacebookClient;
 use Facebook\FileUpload\FacebookResumableUploader;
 use Facebook\FileUpload\FacebookTransferChunk;
 use Facebook\Tests\Fixtures\FakeGraphApiForResumableUpload;
+use PHPUnit\Framework\TestCase;
 
-class FacebookResumableUploaderTest extends \PHPUnit_Framework_TestCase
+class FacebookResumableUploaderTest extends TestCase
 {
     /**
      * @var FacebookApp

--- a/tests/FileUpload/MimetypesTest.php
+++ b/tests/FileUpload/MimetypesTest.php
@@ -24,8 +24,9 @@
 namespace Facebook\Tests\FileUpload;
 
 use Facebook\FileUpload\Mimetypes;
+use PHPUnit\Framework\TestCase;
 
-class MimetypesTest extends \PHPUnit_Framework_TestCase
+class MimetypesTest extends TestCase
 {
 
     /**

--- a/tests/GraphNodes/AbstractGraphNode.php
+++ b/tests/GraphNodes/AbstractGraphNode.php
@@ -25,8 +25,9 @@ namespace Facebook\Tests\GraphNodes;
 
 use Mockery as m;
 use Facebook\GraphNodes\GraphNodeFactory;
+use PHPUnit\Framework\TestCase;
 
-abstract class AbstractGraphNode extends \PHPUnit_Framework_TestCase
+abstract class AbstractGraphNode extends TestCase
 {
     /**
      * @var \Facebook\FacebookResponse|\Mockery\MockInterface

--- a/tests/GraphNodes/CollectionTest.php
+++ b/tests/GraphNodes/CollectionTest.php
@@ -24,8 +24,9 @@
 namespace Facebook\Tests\GraphNodes;
 
 use Facebook\GraphNodes\Collection;
+use PHPUnit\Framework\TestCase;
 
-class CollectionTest extends \PHPUnit_Framework_TestCase
+class CollectionTest extends TestCase
 {
 
     public function testAnExistingPropertyCanBeAccessed()

--- a/tests/GraphNodes/GraphAlbumTest.php
+++ b/tests/GraphNodes/GraphAlbumTest.php
@@ -25,8 +25,9 @@ namespace Facebook\Tests\GraphNodes;
 
 use Mockery as m;
 use Facebook\GraphNodes\GraphNodeFactory;
+use PHPUnit\Framework\TestCase;
 
-class GraphAlbumTest extends \PHPUnit_Framework_TestCase
+class GraphAlbumTest extends TestCase
 {
 
     /**

--- a/tests/GraphNodes/GraphEdgeTest.php
+++ b/tests/GraphNodes/GraphEdgeTest.php
@@ -27,8 +27,9 @@ use Facebook\FacebookApp;
 use Facebook\FacebookRequest;
 use Facebook\GraphNodes\GraphEdge;
 use Facebook\GraphNodes\GraphNode;
+use PHPUnit\Framework\TestCase;
 
-class GraphEdgeTest extends \PHPUnit_Framework_TestCase
+class GraphEdgeTest extends TestCase
 {
 
     /**

--- a/tests/GraphNodes/GraphEventTest.php
+++ b/tests/GraphNodes/GraphEventTest.php
@@ -26,8 +26,9 @@ namespace Facebook\Tests\GraphNodes;
 use Facebook\FacebookResponse;
 use Mockery as m;
 use Facebook\GraphNodes\GraphNodeFactory;
+use PHPUnit\Framework\TestCase;
 
-class GraphEventTest extends \PHPUnit_Framework_TestCase
+class GraphEventTest extends TestCase
 {
     /**
      * @var FacebookResponse

--- a/tests/GraphNodes/GraphGroupTest.php
+++ b/tests/GraphNodes/GraphGroupTest.php
@@ -26,8 +26,9 @@ namespace Facebook\Tests\GraphNodes;
 use Facebook\FacebookResponse;
 use Mockery as m;
 use Facebook\GraphNodes\GraphNodeFactory;
+use PHPUnit\Framework\TestCase;
 
-class GraphGroupTest extends \PHPUnit_Framework_TestCase
+class GraphGroupTest extends TestCase
 {
     /**
      * @var FacebookResponse

--- a/tests/GraphNodes/GraphNodeFactoryTest.php
+++ b/tests/GraphNodes/GraphNodeFactoryTest.php
@@ -27,8 +27,9 @@ use Facebook\FacebookApp;
 use Facebook\FacebookRequest;
 use Facebook\FacebookResponse;
 use Facebook\GraphNodes\GraphNodeFactory;
+use PHPUnit\Framework\TestCase;
 
-class GraphNodeFactoryTest extends \PHPUnit_Framework_TestCase
+class GraphNodeFactoryTest extends TestCase
 {
     /**
      * @var \Facebook\FacebookRequest

--- a/tests/GraphNodes/GraphNodeTest.php
+++ b/tests/GraphNodes/GraphNodeTest.php
@@ -24,8 +24,9 @@
 namespace Facebook\Tests\GraphNodes;
 
 use Facebook\GraphNodes\GraphNode;
+use PHPUnit\Framework\TestCase;
 
-class GraphNodeTest extends \PHPUnit_Framework_TestCase
+class GraphNodeTest extends TestCase
 {
     public function testAnEmptyBaseGraphNodeCanInstantiate()
     {

--- a/tests/GraphNodes/GraphObjectFactoryTest.php
+++ b/tests/GraphNodes/GraphObjectFactoryTest.php
@@ -27,11 +27,13 @@ use Facebook\GraphNodes\GraphObjectFactory;
 use Facebook\FacebookApp;
 use Facebook\FacebookRequest;
 use Facebook\FacebookResponse;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @todo v6: Remove this test
  */
-class GraphObjectFactoryTest extends \PHPUnit_Framework_TestCase
+
+class GraphObjectFactoryTest extends TestCase
 {
     /**
      * @var \Facebook\FacebookRequest

--- a/tests/GraphNodes/GraphPageTest.php
+++ b/tests/GraphNodes/GraphPageTest.php
@@ -25,8 +25,9 @@ namespace Facebook\Tests\GraphNodes;
 
 use Mockery as m;
 use Facebook\GraphNodes\GraphNodeFactory;
+use PHPUnit\Framework\TestCase;
 
-class GraphPageTest extends \PHPUnit_Framework_TestCase
+class GraphPageTest extends TestCase
 {
     /**
      * @var \Facebook\FacebookResponse

--- a/tests/GraphNodes/GraphSessionInfoTest.php
+++ b/tests/GraphNodes/GraphSessionInfoTest.php
@@ -25,8 +25,9 @@ namespace Facebook\Tests\GraphNodes;
 
 use Mockery as m;
 use Facebook\GraphNodes\GraphNodeFactory;
+use PHPUnit\Framework\TestCase;
 
-class GraphSessionInfoTest extends \PHPUnit_Framework_TestCase
+class GraphSessionInfoTest extends TestCase
 {
     /**
      * @var \Facebook\FacebookResponse

--- a/tests/GraphNodes/GraphUserTest.php
+++ b/tests/GraphNodes/GraphUserTest.php
@@ -26,8 +26,9 @@ namespace Facebook\Tests\GraphNodes;
 use Facebook\FacebookResponse;
 use Mockery as m;
 use Facebook\GraphNodes\GraphNodeFactory;
+use PHPUnit\Framework\TestCase;
 
-class GraphUserTest extends \PHPUnit_Framework_TestCase
+class GraphUserTest extends TestCase
 {
     /**
      * @var FacebookResponse

--- a/tests/Helpers/FacebookCanvasHelperTest.php
+++ b/tests/Helpers/FacebookCanvasHelperTest.php
@@ -26,8 +26,9 @@ namespace Facebook\Tests\Helpers;
 use Facebook\FacebookApp;
 use Facebook\FacebookClient;
 use Facebook\Helpers\FacebookCanvasHelper;
+use PHPUnit\Framework\TestCase;
 
-class FacebookCanvasHelperTest extends \PHPUnit_Framework_TestCase
+class FacebookCanvasHelperTest extends TestCase
 {
     public $rawSignedRequestAuthorized = 'vdZXlVEQ5NTRRTFvJ7Jeo_kP4SKnBDvbNP0fEYKS0Sg=.eyJvYXV0aF90b2tlbiI6ImZvb190b2tlbiIsImFsZ29yaXRobSI6IkhNQUMtU0hBMjU2IiwiaXNzdWVkX2F0IjoxNDAyNTUxMDMxLCJ1c2VyX2lkIjoiMTIzIn0=';
 

--- a/tests/Helpers/FacebookJavaScriptHelperTest.php
+++ b/tests/Helpers/FacebookJavaScriptHelperTest.php
@@ -26,8 +26,9 @@ namespace Facebook\Tests\Helpers;
 use Facebook\FacebookApp;
 use Facebook\FacebookClient;
 use Facebook\Helpers\FacebookJavaScriptHelper;
+use PHPUnit\Framework\TestCase;
 
-class FacebookJavaScriptHelperTest extends \PHPUnit_Framework_TestCase
+class FacebookJavaScriptHelperTest extends TestCase
 {
     public $rawSignedRequestAuthorized = 'vdZXlVEQ5NTRRTFvJ7Jeo_kP4SKnBDvbNP0fEYKS0Sg=.eyJvYXV0aF90b2tlbiI6ImZvb190b2tlbiIsImFsZ29yaXRobSI6IkhNQUMtU0hBMjU2IiwiaXNzdWVkX2F0IjoxNDAyNTUxMDMxLCJ1c2VyX2lkIjoiMTIzIn0=';
 

--- a/tests/Helpers/FacebookPageTabHelperTest.php
+++ b/tests/Helpers/FacebookPageTabHelperTest.php
@@ -26,8 +26,9 @@ namespace Facebook\Tests\Helpers;
 use Facebook\FacebookApp;
 use Facebook\FacebookClient;
 use Facebook\Helpers\FacebookPageTabHelper;
+use PHPUnit\Framework\TestCase;
 
-class FacebookPageTabHelperTest extends \PHPUnit_Framework_TestCase
+class FacebookPageTabHelperTest extends TestCase
 {
     protected $rawSignedRequestAuthorized = '6Hi26ECjkj347belC0O8b8H5lwiIz5eA6V9VVjTg-HU=.eyJhbGdvcml0aG0iOiJITUFDLVNIQTI1NiIsImlzc3VlZF9hdCI6MzIxLCJvYXV0aF90b2tlbiI6ImZvb190b2tlbiIsInVzZXJfaWQiOiIxMjMiLCJwYWdlIjp7ImlkIjoiNDIiLCJsaWtlZCI6dHJ1ZSwiYWRtaW4iOmZhbHNlfX0=';
 

--- a/tests/Helpers/FacebookRedirectLoginHelperTest.php
+++ b/tests/Helpers/FacebookRedirectLoginHelperTest.php
@@ -30,8 +30,9 @@ use Facebook\Helpers\FacebookRedirectLoginHelper;
 use Facebook\PersistentData\FacebookMemoryPersistentDataHandler;
 use Facebook\Tests\Fixtures\FooPseudoRandomStringGenerator;
 use Facebook\Tests\Fixtures\FooRedirectLoginOAuth2Client;
+use PHPUnit\Framework\TestCase;
 
-class FacebookRedirectLoginHelperTest extends \PHPUnit_Framework_TestCase
+class FacebookRedirectLoginHelperTest extends TestCase
 {
     /**
      * @var FacebookMemoryPersistentDataHandler

--- a/tests/Helpers/FacebookSignedRequestFromInputHelperTest.php
+++ b/tests/Helpers/FacebookSignedRequestFromInputHelperTest.php
@@ -26,8 +26,9 @@ namespace Facebook\Tests\Helpers;
 use Facebook\FacebookApp;
 use Facebook\Tests\Fixtures\FooSignedRequestHelper;
 use Facebook\Tests\Fixtures\FooSignedRequestHelperFacebookClient;
+use PHPUnit\Framework\TestCase;
 
-class FacebookSignedRequestFromInputHelperTest extends \PHPUnit_Framework_TestCase
+class FacebookSignedRequestFromInputHelperTest extends TestCase
 {
     /**
      * @var FooSignedRequestHelper

--- a/tests/Http/GraphRawResponseTest.php
+++ b/tests/Http/GraphRawResponseTest.php
@@ -24,8 +24,9 @@
 namespace Facebook\Tests\Http;
 
 use Facebook\Http\GraphRawResponse;
+use PHPUnit\Framework\TestCase;
 
-class GraphRawResponseTest extends \PHPUnit_Framework_TestCase
+class GraphRawResponseTest extends TestCase
 {
 
     protected $fakeRawProxyHeader = "HTTP/1.0 200 Connection established

--- a/tests/Http/RequestBodyMultipartTest.php
+++ b/tests/Http/RequestBodyMultipartTest.php
@@ -25,8 +25,9 @@ namespace Facebook\Tests\Http;
 
 use Facebook\Http\RequestBodyMultipart;
 use Facebook\FileUpload\FacebookFile;
+use PHPUnit\Framework\TestCase;
 
-class RequestBodyMultipartTest extends \PHPUnit_Framework_TestCase
+class RequestBodyMultipartTest extends TestCase
 {
     public function testCanProperlyEncodeAnArrayOfParams()
     {

--- a/tests/Http/RequestUrlEncodedTest.php
+++ b/tests/Http/RequestUrlEncodedTest.php
@@ -24,8 +24,9 @@
 namespace Facebook\Tests\Http;
 
 use Facebook\Http\RequestBodyUrlEncoded;
+use PHPUnit\Framework\TestCase;
 
-class RequestUrlEncodedTest extends \PHPUnit_Framework_TestCase
+class RequestUrlEncodedTest extends TestCase
 {
     public function testCanProperlyEncodeAnArrayOfParams()
     {

--- a/tests/HttpClients/AbstractTestHttpClient.php
+++ b/tests/HttpClients/AbstractTestHttpClient.php
@@ -23,7 +23,9 @@
  */
 namespace Facebook\Tests\HttpClients;
 
-abstract class AbstractTestHttpClient extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractTestHttpClient extends TestCase
 {
     protected $fakeRawRedirectHeader = "HTTP/1.1 302 Found
 Content-Type: text/html; charset=utf-8

--- a/tests/HttpClients/HttpClientsFactoryTest.php
+++ b/tests/HttpClients/HttpClientsFactoryTest.php
@@ -28,9 +28,9 @@ use Facebook\HttpClients\FacebookGuzzleHttpClient;
 use Facebook\HttpClients\FacebookStreamHttpClient;
 use Facebook\HttpClients\HttpClientsFactory;
 use GuzzleHttp\Client;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class HttpClientsFactoryTest extends PHPUnit_Framework_TestCase
+class HttpClientsFactoryTest extends TestCase
 {
     const COMMON_NAMESPACE = 'Facebook\HttpClients\\';
     const COMMON_INTERFACE = 'Facebook\HttpClients\FacebookHttpClientInterface';

--- a/tests/PersistentData/FacebookMemoryPersistentDataHandlerTest.php
+++ b/tests/PersistentData/FacebookMemoryPersistentDataHandlerTest.php
@@ -24,8 +24,9 @@
 namespace Facebook\Tests\PersistentData;
 
 use Facebook\PersistentData\FacebookMemoryPersistentDataHandler;
+use PHPUnit\Framework\TestCase;
 
-class FacebookMemoryPersistentDataHandlerTest extends \PHPUnit_Framework_TestCase
+class FacebookMemoryPersistentDataHandlerTest extends TestCase
 {
     public function testCanGetAndSetAVirtualValue()
     {

--- a/tests/PersistentData/FacebookSessionPersistentDataHandlerTest.php
+++ b/tests/PersistentData/FacebookSessionPersistentDataHandlerTest.php
@@ -24,8 +24,9 @@
 namespace Facebook\Tests\PersistentData;
 
 use Facebook\PersistentData\FacebookSessionPersistentDataHandler;
+use PHPUnit\Framework\TestCase;
 
-class FacebookSessionPersistentDataHandlerTest extends \PHPUnit_Framework_TestCase
+class FacebookSessionPersistentDataHandlerTest extends TestCase
 {
     /**
      * @expectedException \Facebook\Exceptions\FacebookSDKException

--- a/tests/PersistentData/PersistentDataFactoryTest.php
+++ b/tests/PersistentData/PersistentDataFactoryTest.php
@@ -26,9 +26,9 @@ namespace Facebook\Tests\PersistentData;
 use Facebook\PersistentData\FacebookMemoryPersistentDataHandler;
 use Facebook\PersistentData\FacebookSessionPersistentDataHandler;
 use Facebook\PersistentData\PersistentDataFactory;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class PersistentDataFactoryTest extends PHPUnit_Framework_TestCase
+class PersistentDataFactoryTest extends TestCase
 {
     const COMMON_NAMESPACE = 'Facebook\PersistentData\\';
     const COMMON_INTERFACE = 'Facebook\PersistentData\PersistentDataInterface';

--- a/tests/PseudoRandomString/McryptPseudoRandomStringGeneratorTest.php
+++ b/tests/PseudoRandomString/McryptPseudoRandomStringGeneratorTest.php
@@ -24,8 +24,9 @@
 namespace Facebook\Tests\PseudoRandomString;
 
 use Facebook\PseudoRandomString\McryptPseudoRandomStringGenerator;
+use PHPUnit\Framework\TestCase;
 
-class McryptPseudoRandomStringGeneratorTest extends \PHPUnit_Framework_TestCase
+class McryptPseudoRandomStringGeneratorTest extends TestCase
 {
     public function testCanGenerateRandomStringOfArbitraryLength()
     {

--- a/tests/PseudoRandomString/OpenSslPseudoRandomStringGeneratorTest.php
+++ b/tests/PseudoRandomString/OpenSslPseudoRandomStringGeneratorTest.php
@@ -24,8 +24,9 @@
 namespace Facebook\Tests\PseudoRandomString;
 
 use Facebook\PseudoRandomString\OpenSslPseudoRandomStringGenerator;
+use PHPUnit\Framework\TestCase;
 
-class OpenSslPseudoRandomStringGeneratorTest extends \PHPUnit_Framework_TestCase
+class OpenSslPseudoRandomStringGeneratorTest extends TestCase
 {
     public function testCanGenerateRandomStringOfArbitraryLength()
     {

--- a/tests/PseudoRandomString/PseudoRandomStringFactoryTest.php
+++ b/tests/PseudoRandomString/PseudoRandomStringFactoryTest.php
@@ -24,9 +24,9 @@
 namespace Facebook\Tests\PseudoRandomString;
 
 use Facebook\PseudoRandomString\PseudoRandomStringGeneratorFactory;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class PseudoRandomStringFactoryTest extends PHPUnit_Framework_TestCase
+class PseudoRandomStringFactoryTest extends TestCase
 {
     const COMMON_NAMESPACE = 'Facebook\PseudoRandomString\\';
     const COMMON_INTERFACE = 'Facebook\PseudoRandomString\PseudoRandomStringGeneratorInterface';

--- a/tests/PseudoRandomString/PseudoRandomStringGeneratorTraitTest.php
+++ b/tests/PseudoRandomString/PseudoRandomStringGeneratorTraitTest.php
@@ -24,8 +24,9 @@
 namespace Facebook\Tests\PseudoRandomString;
 
 use Facebook\Tests\Fixtures\MyFooBarPseudoRandomStringGenerator;
+use PHPUnit\Framework\TestCase;
 
-class PseudoRandomStringGeneratorTraitTest extends \PHPUnit_Framework_TestCase
+class PseudoRandomStringGeneratorTraitTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException

--- a/tests/PseudoRandomString/RandomBytesPseudoRandomStringGeneratorTest.php
+++ b/tests/PseudoRandomString/RandomBytesPseudoRandomStringGeneratorTest.php
@@ -24,8 +24,9 @@
 namespace Facebook\Tests\PseudoRandomString;
 
 use Facebook\PseudoRandomString\RandomBytesPseudoRandomStringGenerator;
+use PHPUnit\Framework\TestCase;
 
-class RandomBytesPseudoRandomStringGeneratorTest extends \PHPUnit_Framework_TestCase
+class RandomBytesPseudoRandomStringGeneratorTest extends TestCase
 {
     public function testCanGenerateRandomStringOfArbitraryLength()
     {

--- a/tests/PseudoRandomString/UrandomPseudoRandomStringGeneratorTest.php
+++ b/tests/PseudoRandomString/UrandomPseudoRandomStringGeneratorTest.php
@@ -24,8 +24,9 @@
 namespace Facebook\Tests\PseudoRandomString;
 
 use Facebook\PseudoRandomString\UrandomPseudoRandomStringGenerator;
+use PHPUnit\Framework\TestCase;
 
-class UrandomPseudoRandomStringGeneratorTest extends \PHPUnit_Framework_TestCase
+class UrandomPseudoRandomStringGeneratorTest extends TestCase
 {
     public function testCanGenerateRandomStringOfArbitraryLength()
     {

--- a/tests/SignedRequestTest.php
+++ b/tests/SignedRequestTest.php
@@ -25,8 +25,9 @@ namespace Facebook\Tests;
 
 use Facebook\FacebookApp;
 use Facebook\SignedRequest;
+use PHPUnit\Framework\TestCase;
 
-class SignedRequestTest extends \PHPUnit_Framework_TestCase
+class SignedRequestTest extends TestCase
 {
     /**
      * @var FacebookApp

--- a/tests/Url/FacebookUrlDetectionHandlerTest.php
+++ b/tests/Url/FacebookUrlDetectionHandlerTest.php
@@ -24,8 +24,9 @@
 namespace Facebook\Tests\Url;
 
 use Facebook\Url\FacebookUrlDetectionHandler;
+use PHPUnit\Framework\TestCase;
 
-class FacebookUrlDetectionHandlerTest extends \PHPUnit_Framework_TestCase
+class FacebookUrlDetectionHandlerTest extends TestCase
 {
     public function testProperlyGeneratesUrlFromCommonScenario()
     {

--- a/tests/Url/FacebookUrlManipulatorTest.php
+++ b/tests/Url/FacebookUrlManipulatorTest.php
@@ -24,8 +24,9 @@
 namespace Facebook\Tests\Url;
 
 use Facebook\Url\FacebookUrlManipulator;
+use PHPUnit\Framework\TestCase;
 
-class FacebookUrlManipulatorTest extends \PHPUnit_Framework_TestCase
+class FacebookUrlManipulatorTest extends TestCase
 {
     /**
      * @dataProvider provideUris


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).