### PR TITLE
Add "new" API Throttle code

### DIFF
--- a/src/Facebook/Exceptions/FacebookResponseException.php
+++ b/src/Facebook/Exceptions/FacebookResponseException.php
@@ -70,7 +70,6 @@ class FacebookResponseException extends FacebookSDKException
     {
         $data = $response->getDecodedBody();
 
-
         if (!isset($data['error']['code']) && isset($data['code'])) {
             $data = ['error' => $data];
         }

--- a/src/Facebook/Exceptions/FacebookResponseException.php
+++ b/src/Facebook/Exceptions/FacebookResponseException.php
@@ -70,6 +70,7 @@ class FacebookResponseException extends FacebookSDKException
     {
         $data = $response->getDecodedBody();
 
+
         if (!isset($data['error']['code']) && isset($data['code'])) {
             $data = ['error' => $data];
         }
@@ -113,7 +114,9 @@ class FacebookResponseException extends FacebookSDKException
             // API Throttling
             case 4:
             case 17:
+            case 32:
             case 341:
+            case 613:
                 return new static($response, new FacebookThrottleException($message, $code));
 
             // Duplicate Post


### PR DESCRIPTION
https://developers.facebook.com/docs/graph-api/advanced/rate-limiting
At the end of this page you see list of rate limiting code.
 
I keep code "341" cause in an other page of the docs :
https://developers.facebook.com/docs/graph-api/using-graph-api#errors
We can see 341 code