### PR TITLE
Refactoring tests

### DIFF
--- a/tests/BatchResponseTest.php
+++ b/tests/BatchResponseTest.php
@@ -107,7 +107,7 @@ class BatchResponseTest extends TestCase
         $this->assertInstanceOf(\IteratorAggregate::class, $batchResponse);
 
         foreach ($batchResponse as $key => $responseEntity) {
-            $this->assertTrue(in_array($key, ['req_one', 'req_two', 'req_three']));
+            $this->assertContains($key, ['req_one', 'req_two', 'req_three']);
             $this->assertInstanceOf(Response::class, $responseEntity);
         }
     }

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -220,7 +220,7 @@ class Test extends TestCase
             $fb->getClient()->getBaseGraphUrl()
         );
         $this->assertInstanceOf('Facebook\BatchRequest', $batchRequest);
-        $this->assertEquals(0, count($batchRequest->getRequests()));
+        $this->assertCount(0, $batchRequest->getRequests());
     }
 
     public function testCanInjectCustomHandlers()

--- a/tests/GraphNode/CollectionTest.php
+++ b/tests/GraphNode/CollectionTest.php
@@ -108,9 +108,7 @@ class CollectionTest extends TestCase
     {
         $collection = new Collection(['foo', 'bar', 'baz']);
 
-        $collectionCount = count($collection);
-
-        $this->assertEquals(3, $collectionCount);
+        $this->assertCount(3, $collection);
     }
 
     public function testACollectionCanBeAccessedAsAnArray()

--- a/tests/GraphNode/GraphAchievementTest.php
+++ b/tests/GraphNode/GraphAchievementTest.php
@@ -66,7 +66,7 @@ class GraphAchievementTest extends AbstractGraphNode
 
         $isNoFeedStory = $graphNode->isNoFeedStory();
 
-        $this->assertTrue(is_bool($isNoFeedStory));
+        $this->assertInternalType('bool', $isNoFeedStory);
     }
 
     public function testDatesGetCastToDateTime()

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -182,7 +182,7 @@ class RequestTest extends TestCase
 
         $this->assertTrue($request->containsFileUploads());
         $this->assertFalse($request->containsVideoUploads());
-        $this->assertFalse(isset($actualParams['source']));
+        $this->assertArrayNotHasKey('source', $actualParams);
         $this->assertEquals('Foo Bar', $actualParams['name']);
     }
 
@@ -200,7 +200,7 @@ class RequestTest extends TestCase
 
         $this->assertTrue($request->containsFileUploads());
         $this->assertTrue($request->containsVideoUploads());
-        $this->assertFalse(isset($actualParams['source']));
+        $this->assertArrayNotHasKey('source', $actualParams);
         $this->assertEquals('Foo Bar', $actualParams['name']);
     }
 }


### PR DESCRIPTION
I've refactored some tests, using:
- `assertContains` instead of `in_array` function;
- `assertCount` instead of `count` function;
- `assertInternalType`, avoiding using `is_*` functions;
- `assertArrayNotHasKey` instead of `isset` function;