### PR TITLE
Rework GraphNode API

### DIFF
--- a/src/GraphNode/GraphNode.php
+++ b/src/GraphNode/GraphNode.php
@@ -25,7 +25,7 @@ namespace Facebook\GraphNode;
 /**
  * @package Facebook
  */
-class GraphNode implements \ArrayAccess, \Countable, \IteratorAggregate
+class GraphNode implements \ArrayAccess, \IteratorAggregate
 {
     /**
      * @var array maps object key names to Graph object types
@@ -124,16 +124,6 @@ class GraphNode implements \ArrayAccess, \Countable, \IteratorAggregate
     public function asJson($options = 0)
     {
         return json_encode($this->uncastFields(), $options);
-    }
-
-    /**
-     * Count the number of fields in the collection.
-     *
-     * @return int
-     */
-    public function count()
-    {
-        return count($this->fields);
     }
 
     /**

--- a/src/GraphNode/GraphNode.php
+++ b/src/GraphNode/GraphNode.php
@@ -249,33 +249,6 @@ class GraphNode implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
-     * Detects an ISO 8601 formatted string.
-     *
-     * @param string $string
-     *
-     * @return bool
-     *
-     * @see https://developers.facebook.com/docs/graph-api/using-graph-api/#readmodifiers
-     * @see http://www.cl.cam.ac.uk/~mgk25/iso-time.html
-     * @see http://en.wikipedia.org/wiki/ISO_8601
-     */
-    public function isIso8601DateString($string)
-    {
-        // This insane regex was yoinked from here:
-        // http://www.pelagodesign.com/blog/2009/05/20/iso-8601-date-validation-that-doesnt-suck/
-        // ...and I'm all like:
-        // http://thecodinglove.com/post/95378251969/when-code-works-and-i-dont-know-why
-        $crazyInsaneRegexThatSomehowDetectsIso8601 = '/^([\+-]?\d{4}(?!\d{2}\b))'
-            . '((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?'
-            . '|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d'
-            . '|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])'
-            . '((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d'
-            . '([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$/';
-
-        return preg_match($crazyInsaneRegexThatSomehowDetectsIso8601, $string) === 1;
-    }
-
-    /**
      * Casts a date value from Graph to DateTime.
      *
      * @param int|string $value
@@ -336,5 +309,32 @@ class GraphNode implements \ArrayAccess, \IteratorAggregate
             'expires_at',
             'publish_time'
         ], true);
+    }
+
+    /**
+     * Detects an ISO 8601 formatted string.
+     *
+     * @param string $string
+     *
+     * @return bool
+     *
+     * @see https://developers.facebook.com/docs/graph-api/using-graph-api/#readmodifiers
+     * @see http://www.cl.cam.ac.uk/~mgk25/iso-time.html
+     * @see http://en.wikipedia.org/wiki/ISO_8601
+     */
+    private function isIso8601DateString($string)
+    {
+        // This insane regex was yoinked from here:
+        // http://www.pelagodesign.com/blog/2009/05/20/iso-8601-date-validation-that-doesnt-suck/
+        // ...and I'm all like:
+        // http://thecodinglove.com/post/95378251969/when-code-works-and-i-dont-know-why
+        $crazyInsaneRegexThatSomehowDetectsIso8601 = '/^([\+-]?\d{4}(?!\d{2}\b))'
+            . '((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?'
+            . '|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d'
+            . '|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])'
+            . '((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d'
+            . '([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$/';
+
+        return preg_match($crazyInsaneRegexThatSomehowDetectsIso8601, $string) === 1;
     }
 }

--- a/src/GraphNode/GraphNode.php
+++ b/src/GraphNode/GraphNode.php
@@ -103,18 +103,6 @@ class GraphNode implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
-     * Run a map over each field.
-     *
-     * @param \Closure $callback
-     *
-     * @return static
-     */
-    public function map(\Closure $callback)
-    {
-        return new static(array_map($callback, $this->fields, array_keys($this->fields)));
-    }
-
-    /**
      * Get all fields as JSON.
      *
      * @param int $options

--- a/src/GraphNode/GraphNode.php
+++ b/src/GraphNode/GraphNode.php
@@ -25,7 +25,7 @@ namespace Facebook\GraphNode;
 /**
  * @package Facebook
  */
-class GraphNode implements \IteratorAggregate
+class GraphNode
 {
     /**
      * @var array maps object key names to Graph object types
@@ -100,16 +100,6 @@ class GraphNode implements \IteratorAggregate
 
             return $value;
         }, $this->fields);
-    }
-
-    /**
-     * Get an iterator for the fields.
-     *
-     * @return \ArrayIterator
-     */
-    public function getIterator()
-    {
-        return new \ArrayIterator($this->fields);
     }
 
     /**

--- a/src/GraphNode/GraphNode.php
+++ b/src/GraphNode/GraphNode.php
@@ -200,37 +200,6 @@ class GraphNode implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
-     * Casts a date value from Graph to DateTime.
-     *
-     * @param int|string $value
-     *
-     * @return \DateTime
-     */
-    public function castToDateTime($value)
-    {
-        if (is_int($value)) {
-            $dt = new \DateTime();
-            $dt->setTimestamp($value);
-        } else {
-            $dt = new \DateTime($value);
-        }
-
-        return $dt;
-    }
-
-    /**
-     * Casts a birthday value from Graph to Birthday.
-     *
-     * @param string $value
-     *
-     * @return Birthday
-     */
-    public function castToBirthday($value)
-    {
-        return new Birthday($value);
-    }
-
-    /**
      * Getter for $graphNodeMap.
      *
      * @return array
@@ -336,5 +305,36 @@ class GraphNode implements \ArrayAccess, \IteratorAggregate
             . '([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$/';
 
         return preg_match($crazyInsaneRegexThatSomehowDetectsIso8601, $string) === 1;
+    }
+
+    /**
+     * Casts a date value from Graph to DateTime.
+     *
+     * @param int|string $value
+     *
+     * @return \DateTime
+     */
+    private function castToDateTime($value)
+    {
+        if (is_int($value)) {
+            $dt = new \DateTime();
+            $dt->setTimestamp($value);
+        } else {
+            $dt = new \DateTime($value);
+        }
+
+        return $dt;
+    }
+
+    /**
+     * Casts a birthday value from Graph to Birthday.
+     *
+     * @param string $value
+     *
+     * @return Birthday
+     */
+    private function castToBirthday($value)
+    {
+        return new Birthday($value);
     }
 }

--- a/src/GraphNode/GraphNode.php
+++ b/src/GraphNode/GraphNode.php
@@ -276,28 +276,6 @@ class GraphNode implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
-     * Determines if a value from Graph should be cast to DateTime.
-     *
-     * @param string $key
-     *
-     * @return bool
-     */
-    public function shouldCastAsDateTime($key)
-    {
-        return in_array($key, [
-            'created_time',
-            'updated_time',
-            'start_time',
-            'stop_time',
-            'end_time',
-            'backdated_time',
-            'issued_at',
-            'expires_at',
-            'publish_time'
-        ], true);
-    }
-
-    /**
      * Casts a date value from Graph to DateTime.
      *
      * @param int|string $value
@@ -336,5 +314,27 @@ class GraphNode implements \ArrayAccess, \IteratorAggregate
     public static function getNodeMap()
     {
         return static::$graphNodeMap;
+    }
+
+    /**
+     * Determines if a value from Graph should be cast to DateTime.
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
+    private function shouldCastAsDateTime($key)
+    {
+        return in_array($key, [
+            'created_time',
+            'updated_time',
+            'start_time',
+            'stop_time',
+            'end_time',
+            'backdated_time',
+            'issued_at',
+            'expires_at',
+            'publish_time'
+        ], true);
     }
 }

--- a/src/GraphNode/GraphNode.php
+++ b/src/GraphNode/GraphNode.php
@@ -200,25 +200,6 @@ class GraphNode implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
-     * Uncasts any auto-casted datatypes.
-     * Basically the reverse of castFields().
-     *
-     * @return array
-     */
-    public function uncastFields()
-    {
-        $fields = $this->asArray();
-
-        return array_map(function ($v) {
-            if ($v instanceof \DateTime) {
-                return $v->format(\DateTime::ISO8601);
-            }
-
-            return $v;
-        }, $fields);
-    }
-
-    /**
      * Casts a date value from Graph to DateTime.
      *
      * @param int|string $value
@@ -287,6 +268,25 @@ class GraphNode implements \ArrayAccess, \IteratorAggregate
         }
 
         return $fields;
+    }
+
+    /**
+     * Uncasts any auto-casted datatypes.
+     * Basically the reverse of castFields().
+     *
+     * @return array
+     */
+    private function uncastFields()
+    {
+        $fields = $this->asArray();
+
+        return array_map(function ($v) {
+            if ($v instanceof \DateTime) {
+                return $v->format(\DateTime::ISO8601);
+            }
+
+            return $v;
+        }, $fields);
     }
 
     /**

--- a/src/GraphNode/GraphNode.php
+++ b/src/GraphNode/GraphNode.php
@@ -103,18 +103,6 @@ class GraphNode implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
-     * Get all fields as JSON.
-     *
-     * @param int $options
-     *
-     * @return string
-     */
-    public function asJson($options = 0)
-    {
-        return json_encode($this->uncastFields(), $options);
-    }
-
-    /**
      * Get an iterator for the fields.
      *
      * @return \ArrayIterator
@@ -184,7 +172,7 @@ class GraphNode implements \ArrayAccess, \IteratorAggregate
      */
     public function __toString()
     {
-        return $this->asJson();
+        return json_encode($this->uncastFields());
     }
 
     /**

--- a/src/GraphNode/GraphNode.php
+++ b/src/GraphNode/GraphNode.php
@@ -25,7 +25,7 @@ namespace Facebook\GraphNode;
 /**
  * @package Facebook
  */
-class GraphNode implements \ArrayAccess, \IteratorAggregate
+class GraphNode implements \IteratorAggregate
 {
     /**
      * @var array maps object key names to Graph object types
@@ -110,59 +110,6 @@ class GraphNode implements \ArrayAccess, \IteratorAggregate
     public function getIterator()
     {
         return new \ArrayIterator($this->fields);
-    }
-
-    /**
-     * Determine if an item exists at an offset.
-     *
-     * @param mixed $key
-     *
-     * @return bool
-     */
-    public function offsetExists($key)
-    {
-        return array_key_exists($key, $this->fields);
-    }
-
-    /**
-     * Get an item at a given offset.
-     *
-     * @param mixed $key
-     *
-     * @return mixed
-     */
-    public function offsetGet($key)
-    {
-        return $this->fields[$key];
-    }
-
-    /**
-     * Set the item at a given offset.
-     *
-     * @param mixed $key
-     * @param mixed $value
-     *
-     * @return void
-     */
-    public function offsetSet($key, $value)
-    {
-        if (is_null($key)) {
-            $this->fields[] = $value;
-        } else {
-            $this->fields[$key] = $value;
-        }
-    }
-
-    /**
-     * Unset the item at a given offset.
-     *
-     * @param string $key
-     *
-     * @return void
-     */
-    public function offsetUnset($key)
-    {
-        unset($this->fields[$key]);
     }
 
     /**

--- a/src/GraphNode/GraphNode.php
+++ b/src/GraphNode/GraphNode.php
@@ -37,7 +37,7 @@ class GraphNode implements \ArrayAccess, \IteratorAggregate
      *
      * @var array
      */
-    protected $fields = [];
+    private $fields = [];
 
     /**
      * Init this Graph object.

--- a/src/GraphNode/GraphNode.php
+++ b/src/GraphNode/GraphNode.php
@@ -81,7 +81,7 @@ class GraphNode implements \ArrayAccess, \IteratorAggregate
      *
      * @return array
      */
-    public function all()
+    public function getFields()
     {
         return $this->fields;
     }

--- a/src/GraphNode/GraphNode.php
+++ b/src/GraphNode/GraphNode.php
@@ -200,36 +200,6 @@ class GraphNode implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
-     * Iterates over an array and detects the types each node
-     * should be cast to and returns all the fields as an array.
-     *
-     * @TODO Add auto-casting to AccessToken entities.
-     *
-     * @param array $data the array to iterate over
-     *
-     * @return array
-     */
-    public function castFields(array $data)
-    {
-        $fields = [];
-
-        foreach ($data as $k => $v) {
-            if ($this->shouldCastAsDateTime($k)
-                && (is_numeric($v)
-                    || $this->isIso8601DateString($v))
-            ) {
-                $fields[$k] = $this->castToDateTime($v);
-            } elseif ($k === 'birthday') {
-                $fields[$k] = $this->castToBirthday($v);
-            } else {
-                $fields[$k] = $v;
-            }
-        }
-
-        return $fields;
-    }
-
-    /**
      * Uncasts any auto-casted datatypes.
      * Basically the reverse of castFields().
      *
@@ -287,6 +257,36 @@ class GraphNode implements \ArrayAccess, \IteratorAggregate
     public static function getNodeMap()
     {
         return static::$graphNodeMap;
+    }
+
+    /**
+     * Iterates over an array and detects the types each node
+     * should be cast to and returns all the fields as an array.
+     *
+     * @TODO Add auto-casting to AccessToken entities.
+     *
+     * @param array $data the array to iterate over
+     *
+     * @return array
+     */
+    private function castFields(array $data)
+    {
+        $fields = [];
+
+        foreach ($data as $k => $v) {
+            if ($this->shouldCastAsDateTime($k)
+                && (is_numeric($v)
+                    || $this->isIso8601DateString($v))
+            ) {
+                $fields[$k] = $this->castToDateTime($v);
+            } elseif ($k === 'birthday') {
+                $fields[$k] = $this->castToBirthday($v);
+            } else {
+                $fields[$k] = $v;
+            }
+        }
+
+        return $fields;
     }
 
     /**

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -274,7 +274,7 @@ class Test extends TestCase
         $nextPage = $fb->next($graphEdge);
         $this->assertInstanceOf(GraphEdge::class, $nextPage);
         $this->assertInstanceOf(GraphUser::class, $nextPage[0]);
-        $this->assertEquals('Foo', $nextPage[0]['name']);
+        $this->assertEquals('Foo', $nextPage[0]->getField('name'));
 
         $lastResponse = $fb->getLastResponse();
         $this->assertInstanceOf(Response::class, $lastResponse);

--- a/tests/GraphNode/GraphEdgeTest.php
+++ b/tests/GraphNode/GraphEdgeTest.php
@@ -103,29 +103,20 @@ class GraphEdgeTest extends TestCase
         $graphEdge = new GraphEdge(
             $this->request,
             [
-                new GraphNode(['name' => 'dummy']),
-                new GraphNode(['name' => 'dummy']),
+                new GraphNode(['name' => 'dummy1']),
+                new GraphNode(['name' => 'dummy2']),
             ],
             ['paging' => $this->pagination],
             '/1234567890/likes'
         );
 
-        $graphEdge = $graphEdge->map(function (GraphNode $node) {
-            $node['name'] = str_replace('dummy', 'foo', $node['name']);
-            return $node;
+        $output = '';
+
+        $graphEdge->map(function (GraphNode $node) use (&$output) {
+            $output .= $node->getField('name');
         });
 
-        $graphEdgeToCompare = new GraphEdge(
-            $this->request,
-            [
-                new GraphNode(['name' => 'foo']),
-                new GraphNode(['name' => 'foo'])
-            ],
-            ['paging' => $this->pagination],
-            '/1234567890/likes'
-        );
-
-        $this->assertEquals($graphEdgeToCompare, $graphEdge);
+        $this->assertEquals('dummy1dummy2', $output);
     }
 
     public function testAnExistingPropertyCanBeAccessed()

--- a/tests/GraphNode/GraphNodeFactoryTest.php
+++ b/tests/GraphNode/GraphNodeFactoryTest.php
@@ -348,19 +348,19 @@ class GraphNodeFactoryTest extends TestCase
 
         // Story
         $storyObject = $graphNode[0];
-        $this->assertInstanceOf(GraphNode::class, $storyObject['from']);
-        $this->assertInstanceOf(GraphEdge::class, $storyObject['likes']);
-        $this->assertInstanceOf(GraphEdge::class, $storyObject['comments']);
+        $this->assertInstanceOf(GraphNode::class, $storyObject->getField('from'));
+        $this->assertInstanceOf(GraphEdge::class, $storyObject->getField('likes'));
+        $this->assertInstanceOf(GraphEdge::class, $storyObject->getField('comments'));
 
         // Story Comments
-        $storyComments = $storyObject['comments'];
+        $storyComments = $storyObject->getField('comments');
         $firstStoryComment = $storyComments[0];
-        $this->assertInstanceOf(GraphNode::class, $firstStoryComment['from']);
+        $this->assertInstanceOf(GraphNode::class, $firstStoryComment->getField('from'));
 
         // Message
         $messageObject = $graphNode[1];
-        $this->assertInstanceOf(GraphEdge::class, $messageObject['to']);
-        $toUsers = $messageObject['to'];
+        $this->assertInstanceOf(GraphEdge::class, $messageObject->getField('to'));
+        $toUsers = $messageObject->getField('to');
         $this->assertInstanceOf(GraphNode::class, $toUsers[0]);
     }
 
@@ -422,10 +422,10 @@ class GraphNodeFactoryTest extends TestCase
         $factory = new GraphNodeFactory($res);
         $graphEdge = $factory->makeGraphEdge();
         $topGraphEdge = $graphEdge->getParentGraphEdge();
-        $childGraphEdgeOne = $graphEdge[0]['likes']->getParentGraphEdge();
-        $childGraphEdgeTwo = $graphEdge[1]['likes']->getParentGraphEdge();
-        $childGraphEdgeThree = $graphEdge[1]['photos']->getParentGraphEdge();
-        $childGraphEdgeFour = $graphEdge[1]['photos'][0]['likes']->getParentGraphEdge();
+        $childGraphEdgeOne = $graphEdge[0]->getField('likes')->getParentGraphEdge();
+        $childGraphEdgeTwo = $graphEdge[1]->getField('likes')->getParentGraphEdge();
+        $childGraphEdgeThree = $graphEdge[1]->getField('photos')->getParentGraphEdge();
+        $childGraphEdgeFour = $graphEdge[1]->getField('photos')[0]->getField('likes')->getParentGraphEdge();
 
         $this->assertNull($topGraphEdge);
         $this->assertEquals('/111/likes', $childGraphEdgeOne);

--- a/tests/GraphNode/GraphNodeTest.php
+++ b/tests/GraphNode/GraphNodeTest.php
@@ -66,29 +66,38 @@ class GraphNodeTest extends TestCase
         yield ['publish_time'];
     }
 
-    public function testDatesThatShouldBeCastAsDateTimeObjectsAreDetected()
+    /**
+     * @dataProvider provideValidDateTimeFieldValues
+     */
+    public function testIsCastDateTimeFieldValueToDateTime($value, $message)
     {
-        $graphNode = new GraphNode();
+        $graphNode = new GraphNode(['created_time' => $value]);
 
-        // Should pass
-        $shouldPass = $graphNode->isIso8601DateString('1985-10-26T01:21:00+0000');
-        $this->assertTrue($shouldPass, 'Expected the valid ISO 8601 formatted date from Back To The Future to pass.');
+        $this->assertInstanceOf(\DateTime::class, $graphNode->getField('created_time'), $message);
+    }
 
-        $shouldPass = $graphNode->isIso8601DateString('1999-12-31');
-        $this->assertTrue($shouldPass, 'Expected the valid ISO 8601 formatted date to party like it\'s 1999.');
+    public static function provideValidDateTimeFieldValues()
+    {
+        yield ['1985-10-26T01:21:00+0000', 'Expected the valid ISO 8601 formatted date from Back To The Future to pass.'];
+        yield ['1999-12-31', 'Expected the valid ISO 8601 formatted date to party like it\'s 1999.'];
+        yield ['2009-05-19T14:39Z', 'Expected the valid ISO 8601 formatted date to pass.'];
+        yield ['2014-W36', 'Expected the valid ISO 8601 formatted date to pass.'];
+    }
 
-        $shouldPass = $graphNode->isIso8601DateString('2009-05-19T14:39Z');
-        $this->assertTrue($shouldPass, 'Expected the valid ISO 8601 formatted date to pass.');
+    /**
+     * @dataProvider provideInvalidDateTimeFieldValues
+     */
+    public function testIsNotCastDateTimeFieldValueToDateTime($value, $message)
+    {
+        $graphNode = new GraphNode(['created_time' => $value]);
 
-        $shouldPass = $graphNode->isIso8601DateString('2014-W36');
-        $this->assertTrue($shouldPass, 'Expected the valid ISO 8601 formatted date to pass.');
+        $this->assertNotInstanceOf(\DateTime::class, $graphNode->getField('created_time'), $message);
+    }
 
-        // Should fail
-        $shouldFail = $graphNode->isIso8601DateString('2009-05-19T14a39r');
-        $this->assertFalse($shouldFail, 'Expected the invalid ISO 8601 format to fail.');
-
-        $shouldFail = $graphNode->isIso8601DateString('foo_time');
-        $this->assertFalse($shouldFail, 'Expected the invalid ISO 8601 format to fail.');
+    public static function provideInvalidDateTimeFieldValues()
+    {
+        yield ['2009-05-19T14a39r', 'Expected the invalid ISO 8601 format to fail.'];
+        yield ['foo_time', 'Expected the invalid ISO 8601 format to fail.'];
     }
 
     public function testATimeStampCanBeConvertedToADateTimeObject()

--- a/tests/GraphNode/GraphNodeTest.php
+++ b/tests/GraphNode/GraphNodeTest.php
@@ -193,8 +193,8 @@ class GraphNodeTest extends TestCase
     {
         $graphNode = new GraphNode(['foo' => 'bar', 'faz' => 'baz']);
 
-        $this->assertEquals('bar', $graphNode['foo']);
-        $this->assertEquals('baz', $graphNode['faz']);
+        $this->assertEquals('bar', $graphNode->getField('foo'));
+        $this->assertEquals('baz', $graphNode->getField('faz'));
     }
 
     public function testAGraphNodeCanBeIteratedOver()

--- a/tests/GraphNode/GraphNodeTest.php
+++ b/tests/GraphNode/GraphNodeTest.php
@@ -188,12 +188,4 @@ class GraphNodeTest extends TestCase
 
         $this->assertEquals('["foo","bar",123]', $graphNodeAsString);
     }
-
-    public function testAGraphNodeCanBeAccessedAsAnArray()
-    {
-        $graphNode = new GraphNode(['foo' => 'bar', 'faz' => 'baz']);
-
-        $this->assertEquals('bar', $graphNode->getField('foo'));
-        $this->assertEquals('baz', $graphNode->getField('faz'));
-    }
 }

--- a/tests/GraphNode/GraphNodeTest.php
+++ b/tests/GraphNode/GraphNodeTest.php
@@ -46,7 +46,7 @@ class GraphNodeTest extends TestCase
     /**
      * @dataProvider provideDateTimeFieldNames
      */
-    public function testIsCastDateTimeFieldsToDateTime($fieldName)
+    public function testCastDateTimeFieldsToDateTime($fieldName)
     {
         $graphNode = new GraphNode([$fieldName => '1989-11-02']);
 
@@ -69,7 +69,7 @@ class GraphNodeTest extends TestCase
     /**
      * @dataProvider provideValidDateTimeFieldValues
      */
-    public function testIsCastDateTimeFieldValueToDateTime($value, $message, $prettyDate = null)
+    public function testCastDateTimeFieldValueToDateTime($value, $message, $prettyDate = null)
     {
         $graphNode = new GraphNode(['created_time' => $value]);
 
@@ -93,7 +93,7 @@ class GraphNodeTest extends TestCase
     /**
      * @dataProvider provideInvalidDateTimeFieldValues
      */
-    public function testIsNotCastDateTimeFieldValueToDateTime($value, $message)
+    public function testNotCastDateTimeFieldValueToDateTime($value, $message)
     {
         $graphNode = new GraphNode(['created_time' => $value]);
 
@@ -130,7 +130,7 @@ class GraphNodeTest extends TestCase
         $this->assertEquals('{"id":"123","created_time":"2014-07-15T03:44:53+0000"}', $graphNodeAsString);
     }
 
-    public function testAnExistingPropertyCanBeAccessed()
+    public function testAnExistingFieldCanBeAccessed()
     {
         $graphNode = new GraphNode(['foo' => 'bar']);
 
@@ -138,7 +138,7 @@ class GraphNodeTest extends TestCase
         $this->assertEquals('bar', $field);
     }
 
-    public function testAMissingPropertyWillReturnNull()
+    public function testAMissingFieldWillReturnNull()
     {
         $graphNode = new GraphNode(['foo' => 'bar']);
         $field = $graphNode->getField('baz');
@@ -146,7 +146,7 @@ class GraphNodeTest extends TestCase
         $this->assertNull($field, 'Expected the property to return null.');
     }
 
-    public function testAMissingPropertyWillReturnTheDefault()
+    public function testAMissingFieldWillReturnTheDefault()
     {
         $graphNode = new GraphNode(['foo' => 'bar']);
 
@@ -168,22 +168,16 @@ class GraphNodeTest extends TestCase
         $this->assertFalse($field);
     }
 
-    public function testTheKeysFromTheCollectionCanBeReturned()
+    public function testTheFieldsFromTheGraphNodeCanBeReturned()
     {
         $graphNode = new GraphNode([
-            'key1' => 'foo',
-            'key2' => 'bar',
-            'key3' => 'baz',
+            'field1' => 'foo',
+            'field2' => 'bar',
+            'field3' => 'baz',
         ]);
 
         $fieldNames = $graphNode->getFieldNames();
-        $this->assertEquals(['key1', 'key2', 'key3'], $fieldNames);
-    }
-
-    public function testAnArrayCanBeInjectedViaTheConstructor()
-    {
-        $graphNode = new GraphNode(['foo', 'bar']);
-        $this->assertEquals(['foo', 'bar'], $graphNode->asArray());
+        $this->assertEquals(['field1', 'field2', 'field3'], $fieldNames);
     }
 
     public function testAGraphNodeCanBeConvertedToAString()
@@ -195,7 +189,7 @@ class GraphNodeTest extends TestCase
         $this->assertEquals('["foo","bar",123]', $graphNodeAsString);
     }
 
-    public function testACollectionCanBeAccessedAsAnArray()
+    public function testAGraphNodeCanBeAccessedAsAnArray()
     {
         $graphNode = new GraphNode(['foo' => 'bar', 'faz' => 'baz']);
 
@@ -203,7 +197,7 @@ class GraphNodeTest extends TestCase
         $this->assertEquals('baz', $graphNode['faz']);
     }
 
-    public function testACollectionCanBeIteratedOver()
+    public function testAGraphNodeCanBeIteratedOver()
     {
         $graphNode = new GraphNode(['foo' => 'bar', 'faz' => 'baz']);
 

--- a/tests/GraphNode/GraphNodeTest.php
+++ b/tests/GraphNode/GraphNodeTest.php
@@ -118,14 +118,14 @@ class GraphNodeTest extends TestCase
         $this->assertInstanceOf(\DateTime::class, $graphNodeAsArray['created_time']);
     }
 
-    public function testGettingAGraphNodeAsJSONWillSafelyRepresentDateTimes()
+    public function testGettingAGraphNodeAsAStringWillSafelyRepresentDateTimes()
     {
         $graphNode = new GraphNode([
             'id' => '123',
             'created_time' => '2014-07-15T03:44:53+0000',
         ]);
 
-        $graphNodeAsString = $graphNode->asJson();
+        $graphNodeAsString = (string) $graphNode;
 
         $this->assertEquals('{"id":"123","created_time":"2014-07-15T03:44:53+0000"}', $graphNodeAsString);
     }
@@ -186,11 +186,11 @@ class GraphNodeTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $graphNode->asArray());
     }
 
-    public function testACollectionCanBeConvertedToProperJson()
+    public function testAGraphNodeCanBeConvertedToAString()
     {
         $graphNode = new GraphNode(['foo', 'bar', 123]);
 
-        $graphNodeAsString = $graphNode->asJson();
+        $graphNodeAsString = (string) $graphNode;
 
         $this->assertEquals('["foo","bar",123]', $graphNodeAsString);
     }

--- a/tests/GraphNode/GraphNodeTest.php
+++ b/tests/GraphNode/GraphNodeTest.php
@@ -43,6 +43,29 @@ class GraphNodeTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $backingData);
     }
 
+    /**
+     * @dataProvider provideDateTimeFieldNames
+     */
+    public function testIsCastDateTimeFieldsToDateTime($fieldName)
+    {
+        $graphNode = new GraphNode([$fieldName => '1989-11-02']);
+
+        $this->assertInstanceOf(\DateTime::class, $graphNode->getField($fieldName));
+    }
+
+    public static function provideDateTimeFieldNames()
+    {
+        yield ['created_time'];
+        yield ['updated_time'];
+        yield ['start_time'];
+        yield ['stop_time'];
+        yield ['end_time'];
+        yield ['backdated_time'];
+        yield ['issued_at'];
+        yield ['expires_at'];
+        yield ['publish_time'];
+    }
+
     public function testDatesThatShouldBeCastAsDateTimeObjectsAreDetected()
     {
         $graphNode = new GraphNode();

--- a/tests/GraphNode/GraphNodeTest.php
+++ b/tests/GraphNode/GraphNodeTest.php
@@ -22,6 +22,7 @@
  */
 namespace Facebook\Tests\GraphNode;
 
+use Facebook\GraphNode\Birthday;
 use Facebook\GraphNode\GraphNode;
 use PHPUnit\Framework\TestCase;
 
@@ -104,6 +105,13 @@ class GraphNodeTest extends TestCase
     {
         yield ['2009-05-19T14a39r', 'Expected the invalid ISO 8601 format to fail.'];
         yield ['foo_time', 'Expected the invalid ISO 8601 format to fail.'];
+    }
+
+    public function testCastBirthdayFieldValueToBirthday()
+    {
+        $graphNode = new GraphNode(['birthday' => '11/02/1989']);
+
+        $this->assertInstanceOf(Birthday::class, $graphNode->getField('birthday'));
     }
 
     public function testGettingGraphNodeAsAnArrayWillNotUncastTheDateTimeObject()

--- a/tests/GraphNode/GraphNodeTest.php
+++ b/tests/GraphNode/GraphNodeTest.php
@@ -201,15 +201,6 @@ class GraphNodeTest extends TestCase
         $this->assertEquals('["foo","bar",123]', $graphNodeAsString);
     }
 
-    public function testACollectionCanBeCounted()
-    {
-        $graphNode = new GraphNode(['foo', 'bar', 'baz']);
-
-        $graphNodeCount = count($graphNode);
-
-        $this->assertEquals(3, $graphNodeCount);
-    }
-
     public function testACollectionCanBeAccessedAsAnArray()
     {
         $graphNode = new GraphNode(['foo' => 'bar', 'faz' => 'baz']);

--- a/tests/GraphNode/GraphNodeTest.php
+++ b/tests/GraphNode/GraphNodeTest.php
@@ -126,46 +126,28 @@ class GraphNodeTest extends TestCase
         $this->assertEquals(1405395893, $timeStamp);
     }
 
-    public function testUncastingAGraphNodeWillUncastTheDateTimeObject()
-    {
-        $graphNodeOne = new GraphNode(['foo', 'bar']);
-        $graphNodeTwo = new GraphNode([
-            'id' => '123',
-            'date' => new \DateTime('2014-07-15T03:44:53+0000'),
-            'some_collection' => $graphNodeOne,
-        ]);
-
-        $uncastArray = $graphNodeTwo->uncastFields();
-
-        $this->assertEquals([
-            'id' => '123',
-            'date' => '2014-07-15T03:44:53+0000',
-            'some_collection' => ['foo', 'bar'],
-        ], $uncastArray);
-    }
-
     public function testGettingGraphNodeAsAnArrayWillNotUncastTheDateTimeObject()
     {
         $graphNode = new GraphNode([
             'id' => '123',
-            'date' => new \DateTime('2014-07-15T03:44:53+0000'),
+            'created_time' => '2014-07-15T03:44:53+0000',
         ]);
 
         $graphNodeAsArray = $graphNode->asArray();
 
-        $this->assertInstanceOf(\DateTime::class, $graphNodeAsArray['date']);
+        $this->assertInstanceOf(\DateTime::class, $graphNodeAsArray['created_time']);
     }
 
-    public function testReturningACollectionAsJasonWillSafelyRepresentDateTimes()
+    public function testGettingAGraphNodeAsJSONWillSafelyRepresentDateTimes()
     {
         $graphNode = new GraphNode([
             'id' => '123',
-            'date' => new \DateTime('2014-07-15T03:44:53+0000'),
+            'created_time' => '2014-07-15T03:44:53+0000',
         ]);
 
         $graphNodeAsString = $graphNode->asJson();
 
-        $this->assertEquals('{"id":"123","date":"2014-07-15T03:44:53+0000"}', $graphNodeAsString);
+        $this->assertEquals('{"id":"123","created_time":"2014-07-15T03:44:53+0000"}', $graphNodeAsString);
     }
 
     public function testAnExistingPropertyCanBeAccessed()

--- a/tests/GraphNode/GraphNodeTest.php
+++ b/tests/GraphNode/GraphNodeTest.php
@@ -196,19 +196,4 @@ class GraphNodeTest extends TestCase
         $this->assertEquals('bar', $graphNode->getField('foo'));
         $this->assertEquals('baz', $graphNode->getField('faz'));
     }
-
-    public function testAGraphNodeCanBeIteratedOver()
-    {
-        $graphNode = new GraphNode(['foo' => 'bar', 'faz' => 'baz']);
-
-        $this->assertInstanceOf(\IteratorAggregate::class, $graphNode);
-
-        $newArray = [];
-
-        foreach ($graphNode as $k => $v) {
-            $newArray[$k] = $v;
-        }
-
-        $this->assertEquals(['foo' => 'bar', 'faz' => 'baz'], $newArray);
-    }
 }

--- a/tests/GraphNode/GraphNodeTest.php
+++ b/tests/GraphNode/GraphNodeTest.php
@@ -69,19 +69,25 @@ class GraphNodeTest extends TestCase
     /**
      * @dataProvider provideValidDateTimeFieldValues
      */
-    public function testIsCastDateTimeFieldValueToDateTime($value, $message)
+    public function testIsCastDateTimeFieldValueToDateTime($value, $message, $prettyDate = null)
     {
         $graphNode = new GraphNode(['created_time' => $value]);
 
         $this->assertInstanceOf(\DateTime::class, $graphNode->getField('created_time'), $message);
+
+        if ($prettyDate !== null) {
+            $this->assertEquals($prettyDate, $graphNode->getField('created_time')->format(\DateTime::RFC1036));
+        }
     }
 
     public static function provideValidDateTimeFieldValues()
     {
         yield ['1985-10-26T01:21:00+0000', 'Expected the valid ISO 8601 formatted date from Back To The Future to pass.'];
+        yield ['2014-07-15T03:44:53+0000', 'Expected the valid ISO 8601 formatted date to pass.', 'Tue, 15 Jul 14 03:44:53 +0000'];
         yield ['1999-12-31', 'Expected the valid ISO 8601 formatted date to party like it\'s 1999.'];
         yield ['2009-05-19T14:39Z', 'Expected the valid ISO 8601 formatted date to pass.'];
         yield ['2014-W36', 'Expected the valid ISO 8601 formatted date to pass.'];
+        yield [1405547020, 'Expected the valid timestamp to pass.', 'Wed, 16 Jul 14 23:43:40 +0200'];
     }
 
     /**
@@ -98,32 +104,6 @@ class GraphNodeTest extends TestCase
     {
         yield ['2009-05-19T14a39r', 'Expected the invalid ISO 8601 format to fail.'];
         yield ['foo_time', 'Expected the invalid ISO 8601 format to fail.'];
-    }
-
-    public function testATimeStampCanBeConvertedToADateTimeObject()
-    {
-        $someTimeStampFromGraph = 1405547020;
-        $graphNode = new GraphNode();
-        $dateTime = $graphNode->castToDateTime($someTimeStampFromGraph);
-        $prettyDate = $dateTime->format(\DateTime::RFC1036);
-        $timeStamp = $dateTime->getTimestamp();
-
-        $this->assertInstanceOf(\DateTime::class, $dateTime);
-        $this->assertEquals('Wed, 16 Jul 14 23:43:40 +0200', $prettyDate);
-        $this->assertEquals(1405547020, $timeStamp);
-    }
-
-    public function testAGraphDateStringCanBeConvertedToADateTimeObject()
-    {
-        $someDateStringFromGraph = '2014-07-15T03:44:53+0000';
-        $graphNode = new GraphNode();
-        $dateTime = $graphNode->castToDateTime($someDateStringFromGraph);
-        $prettyDate = $dateTime->format(\DateTime::RFC1036);
-        $timeStamp = $dateTime->getTimestamp();
-
-        $this->assertInstanceOf(\DateTime::class, $dateTime);
-        $this->assertEquals('Tue, 15 Jul 14 03:44:53 +0000', $prettyDate);
-        $this->assertEquals(1405395893, $timeStamp);
     }
 
     public function testGettingGraphNodeAsAnArrayWillNotUncastTheDateTimeObject()


### PR DESCRIPTION
API design decision:
- A node **is not** a "collection of fields", it doesn't make sense to loop over them, count them, etc so all list behavior functions are removed. We care about accessing each specific field.
- We have the `getField()` function, so array access is not needed and less semantic.
As we want to provide as much typed node classes as possible with semantic getter for each field, the array access becomes even more useless.
Not having it will force use to maintain an updated types node API, which is goot IMO.
- Utility functions than were public to make their testing easier are now private, they are not part of what a graph node is.

Better review commit by commit :)