### PR TITLE
Strip 'code' param

### DIFF
--- a/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
@@ -222,7 +222,6 @@ class FacebookRedirectLoginHelper
         $this->resetCsrf();
 
         $redirectUrl = $redirectUrl ?: $this->urlDetectionHandler->getCurrentUrl();
-
         // At minimum we need to remove the 'state' and 'code' params
         $redirectUrl = FacebookUrlManipulator::removeParamsFromUrl($redirectUrl, ['code', 'state']);
 

--- a/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
@@ -222,8 +222,9 @@ class FacebookRedirectLoginHelper
         $this->resetCsrf();
 
         $redirectUrl = $redirectUrl ?: $this->urlDetectionHandler->getCurrentUrl();
-        // At minimum we need to remove the state param
-        $redirectUrl = FacebookUrlManipulator::removeParamsFromUrl($redirectUrl, ['state']);
+
+        // At minimum we need to remove the 'state' and 'code' params
+        $redirectUrl = FacebookUrlManipulator::removeParamsFromUrl($redirectUrl, ['code', 'state']);
 
         return $this->oAuth2Client->getAccessTokenFromCode($code, $redirectUrl);
     }

--- a/tests/Fixtures/FooRedirectLoginOAuth2Client.php
+++ b/tests/Fixtures/FooRedirectLoginOAuth2Client.php
@@ -23,12 +23,13 @@
  */
 namespace Facebook\Tests\Fixtures;
 
+use Facebook\Authentication\AccessToken;
 use Facebook\Authentication\OAuth2Client;
 
 class FooRedirectLoginOAuth2Client extends OAuth2Client
 {
     public function getAccessTokenFromCode($code, $redirectUri = '', $machineId = null)
     {
-        return 'foo_token_from_code|' . $code . '|' . $redirectUri;
+        return new AccessToken('foo_token_from_code|' . $code . '|' . $redirectUri);
     }
 }

--- a/tests/Helpers/FacebookRedirectLoginHelperTest.php
+++ b/tests/Helpers/FacebookRedirectLoginHelperTest.php
@@ -44,6 +44,9 @@ class FacebookRedirectLoginHelperTest extends \PHPUnit_Framework_TestCase
     protected $redirectLoginHelper;
 
     const REDIRECT_URL = 'http://invalid.zzz';
+    const FOO_CODE = "foo_code";
+    const FOO_STATE = "foo_state";
+    const FOO_PARAM = "some_param=blah";
 
     protected function setUp()
     {
@@ -94,10 +97,10 @@ class FacebookRedirectLoginHelperTest extends \PHPUnit_Framework_TestCase
     public function testAnAccessTokenCanBeObtainedFromRedirect()
     {
         $this->persistentDataHandler->set('state', 'foo_state');
-        $_GET['state'] = 'foo_state';
-        $_GET['code'] = 'foo_code';
+        $_GET['state'] = static::FOO_STATE;
+        $_GET['code'] = static::FOO_CODE;
 
-        $fullUrl = self::REDIRECT_URL . '?state=foo_state&code=foo_code&some_param=blah';
+        $fullUrl = self::REDIRECT_URL . '?state=' . static::FOO_STATE . '&code=' . static::FOO_CODE . '&' . static::FOO_PARAM;
 
         $accessToken = $this->redirectLoginHelper->getAccessToken($fullUrl);
 

--- a/tests/Helpers/FacebookRedirectLoginHelperTest.php
+++ b/tests/Helpers/FacebookRedirectLoginHelperTest.php
@@ -102,7 +102,7 @@ class FacebookRedirectLoginHelperTest extends \PHPUnit_Framework_TestCase
         $accessToken = $this->redirectLoginHelper->getAccessToken($fullUrl);
 
         // code and state should be stripped from the URL
-        $expectedUrl = $fullUrl = self::REDIRECT_URL . '?some_param=blah';
+        $expectedUrl = self::REDIRECT_URL . '?some_param=blah';
 
         $this->assertEquals('foo_token_from_code|foo_code|' . $expectedUrl, $accessToken->getValue());
     }

--- a/tests/Helpers/FacebookRedirectLoginHelperTest.php
+++ b/tests/Helpers/FacebookRedirectLoginHelperTest.php
@@ -106,8 +106,9 @@ class FacebookRedirectLoginHelperTest extends \PHPUnit_Framework_TestCase
 
         // code and state should be stripped from the URL
         $expectedUrl = self::REDIRECT_URL . '?' . static::FOO_PARAM;
+        $expectedString = 'foo_token_from_code|' . static::FOO_CODE . '|' . $expectedUrl;
 
-        $this->assertEquals('foo_token_from_code|' . static::FOO_CODE . '|' . $expectedUrl, $accessToken->getValue());
+        $this->assertEquals($expectedString, $accessToken->getValue());
     }
 
     public function testACustomCsprsgCanBeInjected()

--- a/tests/Helpers/FacebookRedirectLoginHelperTest.php
+++ b/tests/Helpers/FacebookRedirectLoginHelperTest.php
@@ -97,9 +97,14 @@ class FacebookRedirectLoginHelperTest extends \PHPUnit_Framework_TestCase
         $_GET['state'] = 'foo_state';
         $_GET['code'] = 'foo_code';
 
-        $accessToken = $this->redirectLoginHelper->getAccessToken(self::REDIRECT_URL);
+        $fullUrl = self::REDIRECT_URL . '?state=foo_state&code=foo_code&some_param=blah';
 
-        $this->assertEquals('foo_token_from_code|foo_code|' . self::REDIRECT_URL, (string)$accessToken);
+        $accessToken = $this->redirectLoginHelper->getAccessToken($fullUrl);
+
+        // code and state should be stripped from the URL
+        $expectedUrl = $fullUrl = self::REDIRECT_URL . '?some_param=blah';
+
+        $this->assertEquals('foo_token_from_code|foo_code|' . $expectedUrl, $accessToken->getValue());
     }
 
     public function testACustomCsprsgCanBeInjected()

--- a/tests/Helpers/FacebookRedirectLoginHelperTest.php
+++ b/tests/Helpers/FacebookRedirectLoginHelperTest.php
@@ -105,9 +105,9 @@ class FacebookRedirectLoginHelperTest extends \PHPUnit_Framework_TestCase
         $accessToken = $this->redirectLoginHelper->getAccessToken($fullUrl);
 
         // code and state should be stripped from the URL
-        $expectedUrl = self::REDIRECT_URL . '?some_param=blah';
+        $expectedUrl = self::REDIRECT_URL . '?' . static::FOO_PARAM;
 
-        $this->assertEquals('foo_token_from_code|foo_code|' . $expectedUrl, $accessToken->getValue());
+        $this->assertEquals('foo_token_from_code|' . static::FOO_CODE . '|' . $expectedUrl, $accessToken->getValue());
     }
 
     public function testACustomCsprsgCanBeInjected()


### PR DESCRIPTION
This pull request fixes #877, since there hasn't been any activity in #905 for 25 days. 

I also adjusted the test to reflect the change and prevent accidental breaking in the future. 

I also changed the return value of `FooRedirectLoginOAuth2Client::getAccessTokenFromCode()` since that's the specified behavior in `OAuth2Client`. 

Please note that this fix is needed for “Strict Redirect URI Matching” which will be required by Facebook in March. 
  