### PR TITLE
Allowing response_type to be overriden for authorization url retrieval

### DIFF
--- a/src/Authentication/OAuth2Client.php
+++ b/src/Authentication/OAuth2Client.php
@@ -129,12 +129,12 @@ class OAuth2Client
      *
      * @return string
      */
-    public function getAuthorizationUrl($redirectUrl, $state, array $scope = [], array $params = [], $separator = '&')
+    public function getAuthorizationUrl($redirectUrl, $state, array $scope = [], array $params = [], $separator = '&', $response_type = 'code')
     {
         $params += [
             'client_id' => $this->app->getId(),
             'state' => $state,
-            'response_type' => 'code',
+            'response_type' => $response_type,
             'sdk' => 'php-sdk-' . Facebook::VERSION,
             'redirect_uri' => $redirectUrl,
             'scope' => implode(',', $scope)


### PR DESCRIPTION
Currently the response type of the getAuthorizationUrl method of the OAuth2Client hard codes a response type of 'code'. Per #916, strict mode requires a response type of 'token'. With respects to backwards compatibility, this allows response type to be overridden with the 'token' literal for example, while defaulting to 'code'