### PR TITLE
TODO v 6.0

### DIFF
--- a/src/Facebook/Authentication/AccessTokenMetadata.php
+++ b/src/Facebook/Authentication/AccessTokenMetadata.php
@@ -83,22 +83,6 @@ class AccessTokenMetadata
     }
 
     /**
-     * Returns a value from the metadata.
-     *
-     * @param string $field   The property to retrieve.
-     * @param mixed  $default The default to return if the property doesn't exist.
-     *
-     * @return mixed
-     *
-     * @deprecated 5.0.0 getProperty() has been renamed to getField()
-     * @todo v6: Remove this method
-     */
-    public function getProperty($field, $default = null)
-    {
-        return $this->getField($field, $default);
-    }
-
-    /**
      * Returns a value from a child property in the metadata.
      *
      * @param string $parentField The parent property.

--- a/src/Facebook/Facebook.php
+++ b/src/Facebook/Facebook.php
@@ -141,6 +141,9 @@ class Facebook
         if (!$config['app_secret']) {
             throw new FacebookSDKException('Required "app_secret" key not supplied in config and could not find fallback environment variable "' . static::APP_SECRET_ENV_NAME . '"');
         }
+        if (!$config['default_graph_version']) {
+            throw new \InvalidArgumentException('Required "default_graph_version" key not supplied in config and could not find fallback environment variable "' . static::DEFAULT_GRAPH_VERSION . '"');
+        }
 
         $this->app = new FacebookApp($config['app_id'], $config['app_secret']);
         $this->client = new FacebookClient(
@@ -159,7 +162,6 @@ class Facebook
             $this->setDefaultAccessToken($config['default_access_token']);
         }
 
-        // @todo v6: Throw an InvalidArgumentException if "default_graph_version" is not set
         $this->defaultGraphVersion = $config['default_graph_version'];
     }
 


### PR DESCRIPTION
Throw an InvalidArgumentException if "default_graph_version" is not set,
Remove method getProperty() since it is renamed to getField()