### PR TITLE
Adding `postJson` to support endpoints that expect 'application/json'.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -159,10 +159,17 @@ class Client
                 'Content-Type' => 'multipart/form-data; boundary=' . $requestBody->getBoundary(),
             ]);
         } else {
-            $requestBody = $request->getUrlEncodedBody();
-            $request->setHeaders([
-                'Content-Type' => 'application/x-www-form-urlencoded',
-            ]);
+            if($request->isJson()) {
+                $requestBody = $request->getJsonEncodedBody();
+                $request->setHeaders([
+                    'Content-Type' => 'application/json',
+                ]);
+            }else{
+                $requestBody = $request->getUrlEncodedBody();
+                $request->setHeaders([
+                    'Content-Type' => 'application/x-www-form-urlencoded',
+                ]);
+            }
         }
 
         return [

--- a/src/Facebook.php
+++ b/src/Facebook.php
@@ -353,6 +353,31 @@ class Facebook
     }
 
     /**
+     * Sends a POST request to Graph with json-encoded parameters and returns the result.
+     *
+     * @param string                  $endpoint
+     * @param array                   $params
+     * @param null|AccessToken|string $accessToken
+     * @param null|string             $eTag
+     * @param null|string             $graphVersion
+     *
+     * @throws SDKException
+     *
+     * @return Response
+     */
+    public function postJson($endpoint, array $params = [], $accessToken = null, $eTag = null, $graphVersion = null)
+    {
+        return $this->sendJsonRequest(
+            'POST',
+            $endpoint,
+            $params,
+            $accessToken,
+            $eTag,
+            $graphVersion
+        );
+    }
+
+    /**
      * Sends a DELETE request to Graph and returns the result.
      *
      * @param string                  $endpoint
@@ -453,6 +478,31 @@ class Facebook
 
         return $this->lastResponse = $this->client->sendRequest($request);
     }
+
+
+    /**
+     * Sends a request to Graph with json-encoded parameters and returns the result.
+     *
+     * @param string                  $method
+     * @param string                  $endpoint
+     * @param array                   $params
+     * @param null|AccessToken|string $accessToken
+     * @param null|string             $eTag
+     * @param null|string             $graphVersion
+     *
+     * @throws SDKException
+     *
+     * @return Response
+     */
+    public function sendJsonRequest($method, $endpoint, array $params = [], $accessToken = null, $eTag = null, $graphVersion = null)
+    {
+        $accessToken = $accessToken ?: $this->defaultAccessToken;
+        $graphVersion = $graphVersion ?: $this->defaultGraphVersion;
+        $request = $this->request($method, $endpoint, $params, $accessToken, $eTag, $graphVersion);
+        $request.useJson(true);
+        return $this->lastResponse = $this->client->sendRequest($request);
+    }
+
 
     /**
      * Sends a batched request to Graph and returns the result.

--- a/src/Http/RequestBodyJsonEncoded.php
+++ b/src/Http/RequestBodyJsonEncoded.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright 2017 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+namespace Facebook\Http;
+
+/**
+ * @package Facebook
+ */
+class RequestBodyJsonEncoded implements RequestBodyInterface
+{
+    /**
+     * @var array the parameters to send with this request
+     */
+    protected $params = [];
+
+    /**
+     * Creates a new GraphUrlEncodedBody entity.
+     *
+     * @param array $params
+     */
+    public function __construct(array $params)
+    {
+        $this->params = $params;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBody()
+    {
+        return json_encode($this->params);
+    }
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -176,9 +176,28 @@ class ClientTest extends TestCase
         $fbRequest = new Request($this->fbApp, 'token', 'POST', '/foo', ['foo' => 'bar']);
         $response = $this->fbClient->sendRequest($fbRequest);
 
-        $headersSent = $response->getRequest()->getHeaders();
+        $request = $response->getRequest();
+        $headersSent = $request->getHeaders();
+        $body = $request->getUrlEncodedBody()->getBody();
 
         $this->assertEquals('application/x-www-form-urlencoded', $headersSent['Content-Type']);
+        $this->assertContains('foo=bar', $body);
+        $this->assertContains('access_token=token', $body);
+    }
+
+    public function testARequestWithJSONWillJSONEncoded()
+    {
+        $fbRequest = new Request($this->fbApp, 'token', 'POST', '/foo', ['foo' => 'bar']);
+        $fbRequest->useJson(true);
+        $response = $this->fbClient->sendRequest($fbRequest);        
+
+        $request = $response->getRequest();
+        $headersSent = $request->getHeaders();
+        $body = $request->getJsonEncodedBody()->getBody();
+        
+        $this->assertEquals('application/json', $headersSent['Content-Type']);        
+        $this->assertContains('"foo":"bar"', $body);
+        $this->assertNotContains('"access_token": "token"', $body);
     }
 
     public function testARequestWithFilesWillBeMultipart()

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -134,6 +134,12 @@ class RequestTest extends TestCase
         $expectedUrl = '/v0.0/bar';
 
         $this->assertEquals($expectedUrl, $postUrl);
+
+        $jsonRequest = new Request($app, 'foo_token', 'POST', '/bar', ['foo' => 'bar'], null, 'v0.0');
+        $jsonRequest->useJson(true);
+        $jsonUrl = $jsonRequest->getUrl();
+        $expectedUrl = '/v0.0/bar?access_token=foo_token&appsecret_proof=df4256903ba4e23636cc142117aa632133d75c642bd2a68955be1443bd14deb9';
+        $this->assertEquals($expectedUrl, $jsonUrl);
     }
 
     public function testAuthenticationParamsAreStrippedAndReapplied()


### PR DESCRIPTION
Facebook Messenger POST graph endpoints receive 'application/json'
content type while the current SDK doesn't support that since it sends
the request body with multipart or url-encoded.

This patch introduces a new `postJosn()` method with the same
sigunature as `post()` and developers can call Messenger APIs with
a single SDK instead of developing their own API client.