### PR TITLE
Dependency php-http/guzzle6-adapter is required in production

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,13 @@
         "php": "^7.1",
         "psr/http-message": "^1.0",
         "php-http/client-implementation": "^1.0",
+        "php-http/guzzle6-adapter": "^1.0",
         "php-http/httplug": "^1.0",
         "php-http/discovery": "^1.0",
-
         "php-http/message": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.2",
-        "php-http/guzzle6-adapter": "^1.0"
+        "phpunit/phpunit": "^6.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Fixes dependency issue (the prod dependency `php-http/client-implementation` is provided by the dev dependency `php-http/guzzle6-adapter`):
```
$ composer install --no-dev
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested package php-http/client-implementation could not be found in any version, there may be a typo in the package name.
```