### PR TITLE
Updated default Graph API Version

### DIFF
--- a/src/Facebook/Facebook.php
+++ b/src/Facebook/Facebook.php
@@ -58,7 +58,7 @@ class Facebook
     /**
      * @const string Default Graph API version for requests.
      */
-    const DEFAULT_GRAPH_VERSION = 'v2.10';
+    const DEFAULT_GRAPH_VERSION = 'v3.0';
 
     /**
      * @const string The name of the environment variable that contains the app ID.


### PR DESCRIPTION
The default api version "v2.10" is deprecated and causes errors. 

It should be updated and we might as well move to 3.0 already.